### PR TITLE
Fix linter and type checker errors

### DIFF
--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -98,7 +98,7 @@ def transform(func: Callable[..., Any]) -> Callable[..., Transform[Any]]:
         raise ValueError(f"@transform function must have 'ctx' as first parameter, got: {func}")
 
     # Get extra params (everything after ctx)
-    extra_params = params[1:]
+    params[1:]
 
     @functools.wraps(func)
     def factory(*args: Any, **kwargs: Any) -> Transform[Any]:

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -1602,19 +1602,17 @@ class TestGetLinkableFields:
         }
 
         class FakeParent:
+            __tablename__ = "parents"
             def __init__(self, external_id=None, name=None):
                 self.external_id = external_id
                 self.name = name
 
         class FakeChild:
+            __tablename__ = "children"
             def __init__(self, title=None, parent_ref=None):
                 self.title = title
                 self.parent_ref = parent_ref
                 self.parent = None
-
-        # Mock __tablename__ for detection
-        FakeParent.__tablename__ = "parents"
-        FakeChild.__tablename__ = "children"
 
         result = (
             etl(data)
@@ -1635,6 +1633,8 @@ class TestGetLinkableFields:
 
         # Check secondary index was built
         # Access the raw MappingResult which should have indices
+        assert result is not None
+        assert result._raw_results is not None
         parents_result = result._raw_results["parents"]
         assert parents_result.indices is not None
         assert "external_id" in parents_result.indices
@@ -1654,7 +1654,7 @@ class TestNavigationEdgeCases:
         from etielle.fluent import etl
 
         data = {"items": []}
-        result = (
+        (
             etl(data)
             .goto("items").each()
             .map_to(table="items", fields=[
@@ -1733,6 +1733,7 @@ class TestErrorHandlingEdgeCases:
 
         # Should have 1 error collected
         table_errors = result.errors.get("items") or result.errors.get("StrictModel")
+        assert table_errors is not None
         assert len(table_errors) == 1
 
     def test_multiple_errors_per_row_pydantic(self):
@@ -1793,6 +1794,7 @@ class TestErrorHandlingEdgeCases:
         # Should have errors for the invalid record
         assert "records" in result.errors or "StrictRecord" in result.errors
         table_errors = result.errors.get("records") or result.errors.get("StrictRecord")
+        assert table_errors is not None
         assert len(table_errors) == 1
 
         # The error for id=2 should contain validation messages
@@ -1859,6 +1861,8 @@ class TestErrorHandlingEdgeCases:
         # Each table should have 1 error
         user_errors = result.errors.get("users") or result.errors.get("User")
         post_errors = result.errors.get("posts") or result.errors.get("Post")
+        assert user_errors is not None
+        assert post_errors is not None
         assert len(user_errors) == 1
         assert len(post_errors) == 1
 
@@ -1908,6 +1912,7 @@ class TestErrorHandlingEdgeCases:
 
         # Verify failed rows are in errors
         table_errors = result.errors.get("transactions") or result.errors.get("Transaction")
+        assert table_errors is not None
         assert len(table_errors) == 2
 
         # Verify we can identify which IDs failed
@@ -2005,6 +2010,7 @@ class TestErrorHandlingEdgeCases:
 
         # Should have 2 errors
         table_errors = result.errors.get("users") or result.errors.get("RequiredFieldsModel")
+        assert table_errors is not None
         assert len(table_errors) == 2
 
     def test_type_coercion_errors(self):
@@ -2043,6 +2049,7 @@ class TestErrorHandlingEdgeCases:
 
         # Should have 3 errors
         table_errors = result.errors.get("items") or result.errors.get("TypedModel")
+        assert table_errors is not None
         assert len(table_errors) == 3
 
     def test_nested_validation_errors(self):
@@ -2096,6 +2103,7 @@ class TestErrorHandlingEdgeCases:
 
         # Should have 3 errors
         table_errors = result.errors.get("accounts") or result.errors.get("Account")
+        assert table_errors is not None
         assert len(table_errors) == 3
 
     def test_error_messages_are_lists(self):
@@ -2123,6 +2131,7 @@ class TestErrorHandlingEdgeCases:
 
         # Should have 1 error
         table_errors = result.errors.get("items") or result.errors.get("StrictModel")
+        assert table_errors is not None
         assert len(table_errors) == 1
 
         # Error messages should be a list

--- a/tests/test_fluent_sqlalchemy.py
+++ b/tests/test_fluent_sqlalchemy.py
@@ -47,7 +47,7 @@ class TestFluentSQLAlchemy:
             ]
         }
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -75,7 +75,7 @@ class TestFluentSQLAlchemy:
             ]
         }
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -160,7 +160,7 @@ class TestNotNullFKFlushOrdering:
             ]
         }
 
-        result = (
+        (
             etl(data)
             .goto("parents").each()
             .map_to(table=Parent, fields=[
@@ -214,7 +214,7 @@ class TestDictIteration:
             }
         }
 
-        result = (
+        (
             etl(data)
             .goto("questions").each()
             .map_to(table=User, fields=[
@@ -248,7 +248,7 @@ class TestDictIteration:
             }
         }
 
-        result = (
+        (
             etl(data)
             .goto("questions").each()
             .map_to(table=User, fields=[
@@ -282,7 +282,7 @@ class TestDictIteration:
             ]
         }
 
-        result = (
+        (
             etl(data)
             .goto("items").each()
             .map_to(table=User, fields=[
@@ -325,7 +325,7 @@ class TestJoinOnFieldPersistence:
             }
         }
 
-        result = (
+        (
             etl(data)
             .goto("questions").each()
             .map_to(table=User, fields=[
@@ -378,7 +378,7 @@ class TestNullCollectionIteration:
             }
         }
 
-        result = (
+        (
             etl(data)
             .goto("questions").each()
             .goto("subQuestions").each()  # Nested iteration
@@ -414,7 +414,7 @@ class TestSingletonMapping:
             "email": "alice@example.com"
         }
 
-        result = (
+        (
             etl(data)
             .map_to(table=User, fields=[
                 Field("name", get("name")),
@@ -472,7 +472,7 @@ class TestSingletonMapping:
             ]
         }
 
-        result = (
+        (
             etl(data)
             # ROOT-LEVEL singleton user mapping - NO TempField!
             # This means it gets __singleton__ as join key
@@ -530,7 +530,7 @@ class TestDatabaseLoadingEdgeCases:
         # Use merge policy to combine duplicates
         from etielle.instances import AddPolicy
 
-        result = (
+        (
             etl(data)
             .goto("sales").each()
             .map_to(table=User, join_on=["product_name"], fields=[
@@ -569,7 +569,7 @@ class TestDatabaseLoadingEdgeCases:
             ]
         }
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -656,7 +656,7 @@ class TestDatabaseLoadingEdgeCases:
             ]
         }
 
-        result1 = (
+        (
             etl(data_batch1)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -677,7 +677,7 @@ class TestDatabaseLoadingEdgeCases:
             ]
         }
 
-        result2 = (
+        (
             etl(data_batch2)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -697,7 +697,7 @@ class TestDatabaseLoadingEdgeCases:
             ]
         }
 
-        result3 = (
+        (
             etl(data_batch3)
             .goto("users").each()
             .map_to(table=User, fields=[
@@ -734,7 +734,7 @@ class TestDatabaseLoadingEdgeCases:
         }
 
         # Note: User model doesn't have an 'amount' field, so we'll use 'id' to accumulate
-        result = (
+        (
             etl(data)
             .goto("sales").each()
             .map_to(table=User, join_on=["product_name"], fields=[

--- a/tests/test_supabase_adapter.py
+++ b/tests/test_supabase_adapter.py
@@ -13,7 +13,7 @@ To run locally:
 
 import os
 import pytest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 
 from etielle import etl, Field, TempField, get, get_from_parent
 
@@ -32,6 +32,8 @@ requires_supabase = pytest.mark.skipif(
 def supabase_client():
     """Create a Supabase client for testing."""
     from supabase import create_client
+    assert SUPABASE_URL is not None
+    assert SUPABASE_KEY is not None
     return create_client(SUPABASE_URL, SUPABASE_KEY)
 
 
@@ -146,7 +148,7 @@ class TestSupabaseFlush:
 
         mock_supabase_client.table.side_effect = track_table
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -178,7 +180,7 @@ class TestSupabaseFlush:
             {"id": "u1", "name": "Alice"},
         ]
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -218,7 +220,7 @@ class TestSupabaseFlush:
 
         mock_supabase_client.table.side_effect = track_table
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -255,7 +257,7 @@ class TestSupabaseFlush:
 
         mock_supabase_client.table.return_value.insert.return_value.execute.return_value.data = []
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -308,7 +310,7 @@ class TestSupabaseFlush:
 
         mock_supabase_client.table.side_effect = track_table
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -371,7 +373,7 @@ class TestSupabaseFlush:
 
         mock_supabase_client.table.side_effect = track_table
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="users", fields=[
@@ -437,7 +439,7 @@ class TestSupabaseIntegration:
             {"id": "test_u2", "name": "Bob"},
         ]}
 
-        result = (
+        (
             etl(data)
             .goto("users").each()
             .map_to(table="test_users", fields=[
@@ -592,7 +594,7 @@ class TestSupabaseIntegration:
         }
 
         try:
-            result = (
+            (
                 etl(data)
                 .goto("orgs").each()
                 .map_to(table="test_orgs", fields=[

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -16,7 +16,7 @@ from etielle.transforms import (
     parent_key,
 )
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 class _Grand(TypedDict):
@@ -174,7 +174,7 @@ def test_get_out_of_bounds_index_returns_none():
 
 def test_get_from_parent_depth_2_grandparent():
     """get_from_parent(field, depth=2) should access grandparent"""
-    root = {"id": "root", "child": {"id": "child", "grand": {"id": "grand"}}}
+    root: dict[str, Any] = {"id": "root", "child": {"id": "child", "grand": {"id": "grand"}}}
 
     # Build context chain: root -> child -> grand
     # Need to include root level in the chain
@@ -195,7 +195,7 @@ def test_get_from_parent_depth_2_grandparent():
 
 def test_get_from_parent_depth_3_great_grandparent():
     """get_from_parent(field, depth=3) should access great-grandparent"""
-    root = {
+    root: dict[str, Any] = {
         "id": "root",
         "child": {
             "id": "child",


### PR DESCRIPTION
- Remove unused variables (extra_params, result assignments, Mock import)
- Add type annotations for nested dict access in test_transforms.py
- Add None-guard assertions before len() calls on optional values
- Move __tablename__ into class definitions instead of dynamic assignment
- Add assertions for SUPABASE_URL/KEY before create_client()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
