### PR TITLE
feat: Export missing public types for py.typed compliance

### DIFF
--- a/etielle/__init__.py
+++ b/etielle/__init__.py
@@ -1,6 +1,7 @@
 from .core import (
     Context,
     Field as CoreField,  # Renamed to avoid conflict with fluent.Field
+    MappingResult,
     MappingSpec,
     TableEmit,
     Transform,
@@ -15,6 +16,7 @@ from .instances import (
     PydanticBuilder,
     PydanticPartialBuilder,
     TypedDictBuilder,
+    ConstructorBuilder,
     MergePolicy,
     AddPolicy,
     AppendPolicy,
@@ -27,6 +29,7 @@ from .instances import (
 # Fluent API (v3.0.0)
 from .fluent import (
     etl,
+    ErrorMode,
     Field,
     TempField,
     FieldUnion,
@@ -70,6 +73,7 @@ __all__ = [
     # core
     "Context",
     "CoreField",  # Legacy core Field
+    "MappingResult",
     "MappingSpec",
     "TableEmit",
     "Transform",
@@ -82,6 +86,7 @@ __all__ = [
     "PydanticBuilder",
     "PydanticPartialBuilder",
     "TypedDictBuilder",
+    "ConstructorBuilder",
     "MergePolicy",
     "AddPolicy",
     "AppendPolicy",
@@ -91,6 +96,7 @@ __all__ = [
     "FirstNonNullPolicy",
     # Fluent API (v3.0.0)
     "etl",
+    "ErrorMode",
     "Field",
     "TempField",
     "FieldUnion",


### PR DESCRIPTION
## Summary

- Add `MappingResult` export from `core.py` (result type from core executor)
- Add `ConstructorBuilder` export from `instances.py` (builder for ORM models)
- Add `ErrorMode` export from `fluent.py` (type alias used by `etl()`)

All public types are now properly exported from `__init__.py` and included in `__all__`, enabling proper type checking for library consumers.

## Test plan

- [x] All 240 tests pass
- [x] mypy passes on `__init__.py`
- [x] New imports verified working

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)