### PR TITLE
fix: propagate context_slots to compute_child_lookup_values for lookup() support

### DIFF
--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1210,8 +1210,10 @@ class PipelineBuilder:
             # Compute child lookup values (TempField values) by re-traversing
             first_root = self._roots[0] if self._roots else {}
             # This is needed for both session and non-session paths
+            # Pass context_slots with indices so lookup() transforms work
             child_lookup_values = compute_child_lookup_values(
-                first_root, all_specs, self._relationships, self._emissions
+                first_root, all_specs, self._relationships, self._emissions,
+                context_slots={"__indices__": self._indices},
             )
 
             # If no session, bind all relationships now (non-DB use case)

--- a/etielle/relationships.py
+++ b/etielle/relationships.py
@@ -203,6 +203,7 @@ def compute_child_lookup_values(
     traversals: Sequence[TraversalSpec],
     relationships: Sequence[dict[str, Any]],
     emissions: Sequence[dict[str, Any]],
+    context_slots: Dict[str, Any] | None = None,
 ) -> Dict[str, Dict[KeyTuple, Dict[str, Any]]]:
     """
     Compute TempField/Field values for children and parents used in relationship binding.
@@ -252,7 +253,7 @@ def compute_child_lookup_values(
     out: Dict[str, Dict[KeyTuple, Dict[str, Any]]] = {}
 
     for trav in traversals:
-        for ctx in _iter_traversal_nodes(root, trav):
+        for ctx in _iter_traversal_nodes(root, trav, context_slots):
             for emit in trav.emits:
                 # Handle both InstanceEmit and TableEmit
                 if not isinstance(emit, (InstanceEmit, TableEmit)):


### PR DESCRIPTION
## Summary

- Fix bug where `lookup()` transforms failed when used in TempFields for `link_to()` relationship binding
- Add `context_slots` parameter to `compute_child_lookup_values()` to propagate indices
- Add regression tests for lookup with external indices and build_index

## Problem

When using `lookup()` in a TempField that's subsequently used by `link_to()` for relationship binding, the lookup would fail with:
```
ValueError: Index 'X' not found. Available indices: []
```

This occurred because `compute_child_lookup_values()` re-traverses the data to compute TempField values, but wasn't passing `context_slots` (containing `__indices__`) to `_iter_traversal_nodes()`.

## Test plan

- [x] Added `test_lookup_in_tempfield_for_link_to` - tests lookup with external indices
- [x] Added `test_lookup_in_tempfield_with_build_index` - tests lookup with traversal-built indices
- [x] All 257 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)