### PR TITLE
fix: add PyPi environment to release job for secret access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: test
+    environment: PyPi
 
     outputs:
       released: ${{ steps.release.outputs.released }}


### PR DESCRIPTION
## Summary

The `APP_ID` and `PRIVATE_KEY` secrets are stored in the PyPi environment, but the `release` job wasn't using that environment - only the `deploy` job was.

This adds `environment: PyPi` to the release job so it can access the GitHub App credentials needed to bypass branch protection.

## Test plan

- [x] Re-run the release workflow after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)