### PR TITLE
feat: Add backlink() for ORM-native many-to-many relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ parsing. `etielle` helps by:
 5.  [**Mapping Tables**](docs/mapping.qmd): Outputting data with `Field`
     and `TempField`.
 6.  [**Relationships**](docs/relationships.qmd): Linking tables together
-    with `link_to()`.
+    with `link_to()` (many-to-one) and `backlink()` (many-to-many).
 7.  [**Database Loading**](docs/database-loading.qmd): Persisting data
     with `load()` and `run()`.
 
@@ -366,7 +366,7 @@ print(f"Type: {type(user).__name__}, name: {user.name}")
 - **[Mapping Tables](docs/mapping.qmd)** - `Field`, `TempField`, merge
   policies
 - **[Relationships](docs/relationships.qmd)** - Link tables with
-  `link_to()`
+  `link_to()` and `backlink()`
 - **[Database Loading](docs/database-loading.qmd)** - Persist with
   `load().run()`
 

--- a/docs/relationships.qmd
+++ b/docs/relationships.qmd
@@ -1,8 +1,8 @@
 ---
-title: "Relationships: Linking Tables with link_to()"
+title: "Relationships: Linking Tables with link_to() and backlink()"
 ---
 
-**What you'll learn**: How to use `link_to()` to build parent-child relationships between tables, avoiding N+1 database queries.
+**What you'll learn**: How to use `link_to()` for many-to-one and `backlink()` for many-to-many relationships between tables.
 
 **ETL context**: Relationships are part of the **Transform** step---they link child records to parent records in memory before persistence.
 
@@ -336,6 +336,126 @@ TempField("id", get("id"))  # Returns "u1"
 
 # Child key must also be string
 TempField("user_id", get("user_id"))  # Must return "u1", not 1
+```
+
+## Many-to-Many Relationships with `backlink()`
+
+While `link_to()` handles many-to-one relationships (child → parent), `backlink()` handles many-to-many relationships where a parent has a list of children.
+
+### What is `backlink()`?
+
+`backlink()` populates a list attribute on the parent object with matching child objects. This is useful for ORM-native many-to-many relationships where the ORM handles junction tables automatically (e.g., SQLModel, SQLAlchemy).
+
+```python
+from dataclasses import dataclass, field
+from etielle import etl, Field, TempField, get
+
+@dataclass
+class Question:
+    text: str
+    choices: list = field(default_factory=list)  # Will be populated by backlink()
+
+@dataclass
+class Choice:
+    text: str
+
+data = {
+    "questions": [
+        {"id": 1, "text": "What is 2+2?", "choice_ids": [10, 11]},
+    ],
+    "choices": [
+        {"id": 10, "text": "3"},
+        {"id": 11, "text": "4"},
+    ],
+}
+
+result = (
+    etl(data)
+    .goto("questions").each()
+    .map_to(table=Question, fields=[
+        Field("text", get("text")),
+        TempField("id", get("id")),
+        TempField("choice_ids", get("choice_ids")),  # List of child IDs
+    ])
+    .goto_root()
+    .goto("choices").each()
+    .map_to(table=Choice, fields=[
+        Field("text", get("text")),
+        TempField("id", get("id")),
+    ])
+    .backlink(
+        parent=Question,
+        child=Choice,
+        attr="choices",               # Sets question.choices = [...]
+        by={"choice_ids": "id"},      # Parent's choice_ids contains child's id
+    )
+    .run()
+)
+
+# Question now has its choices populated
+question = list(result.tables[Question].values())[0]
+print(f"Question: {question.text}")
+for choice in question.choices:
+    print(f"  - {choice.text}")
+```
+
+### How `backlink()` Works
+
+The `by` parameter mapping is **reversed** from `link_to()`:
+
+| Method | `by` mapping direction | Example |
+|--------|----------------------|---------|
+| `link_to()` | `{child_field: parent_field}` | `by={"user_id": "id"}` |
+| `backlink()` | `{parent_field: child_field}` | `by={"choice_ids": "id"}` |
+
+For `backlink()`, the parent field (`choice_ids`) contains a list of values that match the child field (`id`).
+
+### `backlink()` Reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `parent` | `type \| str` | The parent model class or table name that holds the list |
+| `child` | `type \| str` | The child model class or table name |
+| `attr` | `str` | The list attribute name on the parent to populate |
+| `by` | `dict[str, str]` | Mapping of `{parent_field: child_field}` where parent_field contains list of child IDs |
+
+### Requirements
+
+- Parent's field in `by` must contain a list of child IDs (or a single ID)
+- Child's field in `by` must be indexed (available as TempField)
+- Both tables must be emitted in the pipeline
+- **Not supported with Supabase** - `backlink()` relies on ORM-native junction table handling
+
+### Combining `link_to()` and `backlink()`
+
+You can use both relationship types in the same pipeline:
+
+```python
+result = (
+    etl(data)
+    .goto("users").each()
+    .map_to(table=User, fields=[...])
+
+    .goto_root()
+    .goto("questions").each()
+    .map_to(table=Question, fields=[
+        TempField("user_id", get("user_id")),
+        TempField("choice_ids", get("choice_ids")),
+        ...
+    ])
+    .link_to(User, by={"user_id": "id"})  # Many-to-one: Question -> User
+
+    .goto_root()
+    .goto("choices").each()
+    .map_to(table=Choice, fields=[...])
+    .backlink(
+        parent=Question,
+        child=Choice,
+        attr="choices",
+        by={"choice_ids": "id"},
+    )  # Many-to-many: Question.choices = [Choice, ...]
+    .run()
+)
 ```
 
 ## See also

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -12,6 +12,7 @@ from etielle.relationships import (
     compute_relationship_keys,
     bind_many_to_one,
     bind_many_to_one_via_index,
+    bind_backlinks,
 )
 
 
@@ -435,3 +436,226 @@ def test_bind_many_to_one_via_index_not_required():
     assert errors == []
     assert child1.parent is parent1
     assert child2.parent is None
+
+
+def test_bind_backlinks_success():
+    """bind_backlinks should populate parent's list attribute with matching children."""
+    from dataclasses import field
+
+    @dataclass
+    class Question:
+        text: str
+        choices: list = field(default_factory=list)
+
+    @dataclass
+    class Choice:
+        text: str
+
+    question1 = Question(text="Q1")
+    question2 = Question(text="Q2")
+    choice1 = Choice(text="A")
+    choice2 = Choice(text="B")
+    choice3 = Choice(text="C")
+
+    # Parent results with questions keyed
+    parent_result = MappingResult(
+        instances={
+            ("q1",): question1,
+            ("q2",): question2,
+        },
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={},
+    )
+
+    # Child results with choices indexed by ID
+    child_result = MappingResult(
+        instances={
+            ("c1",): choice1,
+            ("c2",): choice2,
+            ("c3",): choice3,
+        },
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={"id": {10: choice1, 11: choice2, 12: choice3}},
+    )
+
+    raw_results = {
+        "questions": parent_result,
+        "choices": child_result,
+    }
+
+    # Backlink spec: question's choice_ids contains choice's id
+    backlinks = [
+        {
+            "type": "backlink",
+            "parent_table": "questions",
+            "child_table": "choices",
+            "attr": "choices",
+            "by": {"choice_ids": "id"},
+        }
+    ]
+
+    # Parent lookup values: each question has a choice_ids list
+    parent_lookup_values = {
+        "questions": {
+            ("q1",): {"choice_ids": [10, 11]},  # Q1 has choices A and B
+            ("q2",): {"choice_ids": [12]},      # Q2 has choice C
+        }
+    }
+
+    errors = bind_backlinks(
+        raw_results, backlinks, parent_lookup_values, fail_on_missing=False
+    )
+
+    assert errors == []
+    assert len(question1.choices) == 2
+    assert choice1 in question1.choices
+    assert choice2 in question1.choices
+    assert len(question2.choices) == 1
+    assert choice3 in question2.choices
+
+
+def test_bind_backlinks_missing_children():
+    """bind_backlinks should handle missing children gracefully."""
+    from dataclasses import field
+
+    @dataclass
+    class Question:
+        text: str
+        choices: list = field(default_factory=list)
+
+    @dataclass
+    class Choice:
+        text: str
+
+    question = Question(text="Q1")
+    choice = Choice(text="A")
+
+    parent_result = MappingResult(
+        instances={("q1",): question},
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={},
+    )
+
+    child_result = MappingResult(
+        instances={("c1",): choice},
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={"id": {10: choice}},  # Only choice 10 exists
+    )
+
+    raw_results = {
+        "questions": parent_result,
+        "choices": child_result,
+    }
+
+    backlinks = [
+        {
+            "type": "backlink",
+            "parent_table": "questions",
+            "child_table": "choices",
+            "attr": "choices",
+            "by": {"choice_ids": "id"},
+        }
+    ]
+
+    # Q1 references choice 10 (exists) and 999 (missing)
+    parent_lookup_values = {
+        "questions": {
+            ("q1",): {"choice_ids": [10, 999]},
+        }
+    }
+
+    # With fail_on_missing=False, errors are returned but no exception raised
+    errors = bind_backlinks(
+        raw_results, backlinks, parent_lookup_values, fail_on_missing=False
+    )
+
+    # The missing child (999) should still be noted but no exception
+    # Since we don't fail on missing, the list should still be set with existing children
+    assert len(question.choices) == 1
+    assert choice in question.choices
+
+    # Test with fail_on_missing=True to verify exception is raised
+    question2 = Question(text="Q2")
+    parent_result2 = MappingResult(
+        instances={("q2",): question2},
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={},
+    )
+    raw_results2 = {
+        "questions": parent_result2,
+        "choices": child_result,
+    }
+    parent_lookup_values2 = {
+        "questions": {
+            ("q2",): {"choice_ids": [999]},  # Only missing child
+        }
+    }
+
+    import pytest
+    with pytest.raises(RuntimeError, match="backlink binding failed"):
+        bind_backlinks(
+            raw_results2, backlinks, parent_lookup_values2, fail_on_missing=True
+        )
+
+
+def test_bind_backlinks_skips_non_backlink_rels():
+    """bind_backlinks should ignore relationships without type='backlink'."""
+    from dataclasses import field
+
+    @dataclass
+    class Question:
+        text: str
+        choices: list = field(default_factory=list)
+
+    question = Question(text="Q1")
+
+    parent_result = MappingResult(
+        instances={("q1",): question},
+        update_errors={},
+        finalize_errors={},
+        stats={},
+        indices={},
+    )
+
+    raw_results = {"questions": parent_result}
+
+    # Mix of link_to and backlink relationships
+    relationships = [
+        {
+            # link_to style - should be skipped
+            "parent_table": "users",
+            "child_table": "posts",
+            "by": {"user_id": "id"},
+        },
+        {
+            # backlink style - should be processed (but no matching data)
+            "type": "backlink",
+            "parent_table": "questions",
+            "child_table": "choices",
+            "attr": "choices",
+            "by": {"choice_ids": "id"},
+        },
+    ]
+
+    parent_lookup_values = {
+        "questions": {
+            ("q1",): {"choice_ids": []},
+        }
+    }
+
+    # Should not error, just skip the non-backlink rel
+    errors = bind_backlinks(
+        raw_results, relationships, parent_lookup_values, fail_on_missing=False
+    )
+
+    assert errors == []


### PR DESCRIPTION
## Summary

- Add `backlink()` method to PipelineBuilder for many-to-many relationship binding
- Add `bind_backlinks()` and `compute_backlink_lookup_values()` to relationships module
- Update `_get_linkable_fields()` to index child fields for backlinks
- Add Supabase error handling (raises `ValueError` if used with Supabase)
- Add comprehensive tests for backlink functionality
- Update documentation with examples

## API

```python
.backlink(
    parent=Question,
    child=Choice,
    attr="choices",           # sets question.choices = [...]
    by={"choice_ids": "id"},  # parent's choice_ids contains child's id
)
```

## Test plan

- [x] All existing tests pass (267 passed, 4 skipped)
- [x] New tests for backlink() method on PipelineBuilder
- [x] New tests for bind_backlinks() in relationships module
- [x] Test Supabase error handling
- [x] Test combining link_to() and backlink()
- [x] Type checking passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)