### PR TITLE
Fix YAML syntax error in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-documentation:
-    if: ${{ !startsWith(github.event.head_commit.message, 'docs: Render README.md') }}
+    if: "${{ !startsWith(github.event.head_commit.message, 'docs: Render README.md') }}"
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Quote the `if:` condition value in publish workflow to fix YAML parsing error
- Add missing trailing newline to workflow file

The workflow was failing with "mapping values are not allowed here" because the unquoted `if:` expression contained `'docs: Render...'` with an embedded colon that confused YAML parsers.

Closes #68

## Test plan
- [ ] Verify workflow YAML passes validation
- [ ] Confirm publish workflow runs successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)