### PR TITLE
feat: Support .each().each() for dict-of-lists and list-of-lists iter…

### DIFF
--- a/docs/navigation.qmd
+++ b/docs/navigation.qmd
@@ -129,6 +129,124 @@ print("Users:", list(result.tables["users"].values()))
 print("Posts:", list(result.tables["posts"].values()))
 ```
 
+## Direct Nested Iteration with `.each().each()`
+
+When you have nested iterable structures without intermediate keys (like a list of lists or a dict of lists), you can chain `.each()` calls directly without an intervening `.goto()`:
+
+### List of Lists
+
+```{python}
+from etielle import etl, Field, node, parent_index
+from etielle.transforms import index
+
+# Matrix data: list of rows, each row is a list of values
+data = {"matrix": [[1, 2, 3], [4, 5, 6]]}
+
+result = (
+    etl(data)
+    .goto("matrix").each().each()  # First each() iterates rows, second iterates cells
+    .map_to(table="cells", fields=[
+        Field("value", node()),           # Current cell value
+        Field("row", parent_index()),     # Row index (0 or 1)
+        Field("col", index()),            # Column index (0, 1, or 2)
+    ])
+    .run()
+)
+
+print("Cells:", list(result.tables["cells"].values()))
+```
+
+### Dict of Lists
+
+For dict-of-lists structures (common in junction table scenarios), use `.each().each()` with `parent_key()` to capture the dict key:
+
+```{python}
+from etielle import etl, Field, node
+from etielle.transforms import index, parent_key
+
+# Question-to-choices mapping
+data = {
+    "question_choices": {
+        "Q1": ["choice_a", "choice_b"],
+        "Q2": ["choice_c", "choice_d", "choice_e"]
+    }
+}
+
+result = (
+    etl(data)
+    .goto("question_choices").each().each()  # First each() iterates dict, second iterates list values
+    .map_to(table="question_choices", fields=[
+        Field("question_id", parent_key()),  # Dict key from outer iteration
+        Field("choice_id", node()),          # Current list item
+        Field("position", index()),          # Index within the list
+    ])
+    .run()
+)
+
+print("Question-Choice mappings:", list(result.tables["question_choices"].values()))
+```
+
+### Mixed Dict and List Nesting
+
+Since `.each()` automatically handles both dicts (iterating key-value pairs) and lists (iterating by index), you can iterate through any combination. Use `key()` or `parent_key()` for dict keys, and `index()` or `parent_index()` for list indices:
+
+```{python}
+from etielle import etl, Field, node, parent_index
+from etielle.transforms import key
+
+# List of dicts: outer is a list, inner values are dicts
+data = {
+    "departments": [
+        {"engineering": 50, "sales": 30},
+        {"engineering": 40, "sales": 25, "marketing": 15}
+    ]
+}
+
+result = (
+    etl(data)
+    .goto("departments").each().each()  # First each() iterates list, second iterates dict
+    .map_to(table="headcount", fields=[
+        Field("quarter", parent_index()),  # List index from outer iteration (0 or 1)
+        Field("department", key()),        # Dict key from inner iteration
+        Field("count", node()),            # Dict value
+    ])
+    .run()
+)
+
+print("Headcount by quarter and department:")
+for row in result.tables["headcount"].values():
+    print(f"  Q{row['quarter']+1} {row['department']}: {row['count']}")
+```
+
+### Triple Nesting
+
+You can chain any number of `.each()` calls for deeper structures:
+
+```{python}
+#| eval: false
+# 3D data structure
+data = {"cube": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]}
+
+result = (
+    etl(data)
+    .goto("cube").each().each().each()  # Three levels of iteration
+    .map_to(table="values", fields=[
+        Field("value", node()),
+        Field("layer", parent_index(depth=2)),  # Grandparent index
+        Field("row", parent_index(depth=1)),    # Parent index
+        Field("col", index()),                   # Current index
+    ])
+    .run()
+)
+```
+
+### When to Use `.each().each()` vs `.each().goto().each()`
+
+| Pattern | Use When | Example Data |
+|---------|----------|--------------|
+| `.each().each()` | Items directly contain iterables | `[[1,2], [3,4]]` or `{"a": [1,2], "b": [3,4]}` |
+| `.each().goto("items").each()` | Items have a named key containing an iterable | `[{"items": [1,2]}, {"items": [3,4]}]` |
+
 ## Deep Nesting (Arbitrary Depth)
 
 Handle arbitrarily deep structures with chained navigation. Use the `depth` parameter in `get_from_parent()` to access ancestors:

--- a/docs/relationships.qmd
+++ b/docs/relationships.qmd
@@ -233,34 +233,38 @@ For relationships with composite keys, include multiple entries in the `by` dict
 })
 ```
 
-## Junction Tables (Reverse Lookups)
+## Junction Tables and Dict-of-Lists
 
-Handle junction tables where the relationship is defined outside the child:
+Handle junction table patterns where the relationship is defined as a dict-of-lists. The `.each().each()` pattern allows direct nested iteration without an intervening `.goto()`:
 
 ``` {python}
-#| eval: false
-# Data: {"userPosts": {"u1": [101, 102], "u2": [103]}}
-# This maps user_id -> list of post_ids
+from etielle import etl, Field, TempField, get, node
+from etielle.transforms import parent_key, index
+
+# Data has a dict-of-lists mapping questions to their choice IDs
+data = {
+    "question_choices": {
+        "Q1": ["c1", "c2"],
+        "Q2": ["c3", "c4", "c5"]
+    }
+}
 
 result = (
     etl(data)
-    .goto("users").each()
-    .map_to(table=User, fields=[...])
-
-    .goto_root()
-    .goto("posts").each()
-    .map_to(table=Post, fields=[...])
-
-    .goto_root()
-    .goto("userPosts").each()    # key() = user_id
-    .each()                       # node() = post_id
-    .map_to(table=Post, join_on=["id"], fields=[
-        TempField("id", node()),
-        TempField("user_id", parent_key())
+    # Use .each().each() to iterate the dict-of-lists
+    .goto("question_choices").each().each()  # First each() iterates dict keys, second iterates list items
+    .map_to(table="junction", fields=[
+        Field("question_id", parent_key()),  # Dict key from outer iteration
+        Field("choice_id", node()),          # List item from inner iteration
+        Field("position", index()),          # Position in the list
     ])
-    .link_to(User, by={"user_id": "id"})
     .run()
 )
+
+# Each combination is extracted
+print("Question-Choice mappings:")
+for row in result.tables["junction"].values():
+    print(f"  {row['question_id']} -> {row['choice_id']} (position {row['position']})")
 ```
 
 ## `link_to()` Reference

--- a/etielle/core.py
+++ b/etielle/core.py
@@ -182,6 +182,7 @@ class TraversalSpec:
     - mode: how to iterate the outer container: "auto" (default), "items" (dict key/value), or "single" (treat as one node)
     - inner_path: optional path inside each outer node to reach an inner container (e.g., ["elements"]). If provided, iterate that container instead of the outer node
     - inner_mode: how to iterate the inner container when inner_path is provided: "auto" (default), "items", or "single"
+    - nested_depth: number of additional nesting levels to iterate when inner_path is None (e.g., for .each().each() at same path). Default 0 means single-level iteration.
     - emits: table emitters to run for each yielded node
     """
 
@@ -190,6 +191,7 @@ class TraversalSpec:
     mode: Literal["auto", "items", "single"] = "auto"
     inner_path: Optional[Sequence[str]] = None
     inner_mode: Literal["auto", "items", "single"] = "auto"
+    nested_depth: int = 0
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
…ation

Add support for chaining .each() calls without intervening .goto() to iterate nested iterables directly. This enables natural iteration of:
- List of lists: [[1,2], [3,4]]
- Dict of lists: {"Q1": ["c1", "c2"], "Q2": ["c3"]}
- List of dicts: [{"a": 1, "b": 2}, {"a": 3}]
- Arbitrarily deep nesting: .each().each().each()

Implementation:
- Add nested_depth field to TraversalSpec to track nesting levels
- Detect consecutive .each() calls at same path in spec building
- Add recursive yield_nested() helper in executor for deep iteration

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)