### PR TITLE
fix: Create GitHub Release before uploading assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,15 @@ jobs:
           git tag ${{ steps.release.outputs.tag }}
           git push origin ${{ github.event.workflow_run.head_branch }} --tags
 
+      - name: Create GitHub Release
+        if: steps.release.outputs.released == 'true'
+        run: |
+          gh release create ${{ steps.release.outputs.tag }} \
+            --title "${{ steps.release.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v10.4.1
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Summary
- Adds a step to manually create the GitHub Release using `gh release create` before calling `publish-action`
- Fixes the issue where releases were published to PyPI but no GitHub Release was created

## Root Cause
The `python-semantic-release` action was configured with `vcs_release: "false"` to allow manual commit/tag/push for branch protection bypass. However, this also prevented GitHub Release creation, causing `publish-action` to fail with:
```
WARNING  No release corresponds to tag v3.6.0, can't upload dists
```

## Test plan
- [ ] Merge this PR and make a releasable commit (e.g., `feat:` or `fix:`)
- [ ] Verify the release workflow creates both a GitHub Release and publishes to PyPI

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)