### PR TITLE
feat!: component-scoped flush/evict and single-pass binding (issue #9A)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,45 @@
+# Issue 9A benchmarks
+
+Benchmark harness for component-scoped flush/evict (issue #74).
+
+## Run before/after
+
+Capture baseline on `main`:
+
+```bash
+uv run python benchmarks/bench_issue_9a.py run --scale 500 --output artifacts/bench-before.json
+uv run python benchmarks/bench_issue_9a.py run --scale 500 --load --output artifacts/bench-before-load.json
+```
+
+After implementing issue 9A:
+
+```bash
+uv run python benchmarks/bench_issue_9a.py run --scale 500 --output artifacts/bench-after.json
+uv run python benchmarks/bench_issue_9a.py run --scale 500 --load --output artifacts/bench-after-load.json
+```
+
+Compare:
+
+```bash
+uv run python benchmarks/bench_issue_9a.py compare \
+  artifacts/bench-before-load.json artifacts/bench-after-load.json \
+  --markdown artifacts/bench-comparison.md
+```
+
+## Metrics
+
+- **wall_seconds**: end-to-end pipeline time
+- **heap_peak_bytes**: Python heap peak via `tracemalloc`
+- **rss_peak_kb**: process RSS peak via `resource.getrusage`
+- **rows_mapped**: total mapped rows from `PipelineResult.stats`
+
+## Scenarios
+
+1. **no_relationships** — independent tables, no relationship graph
+2. **many_components** — many isolated parent/child pairs (capped at 100 components)
+3. **single_component** — one connected users/posts graph
+4. **eager_dimension_without_eager** — shared tag table without `load_eager`
+5. **eager_dimension_with_eager** — same shape with `load_eager(Tag)`
+
+Use `--load` to measure load-mode behavior where flushed instances are not retained
+in `PipelineResult.tables`.

--- a/benchmarks/bench_issue_9a.py
+++ b/benchmarks/bench_issue_9a.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Benchmark harness for issue #9A: component-scoped flush/evict.
+
+Measures wall time, Python heap peak (tracemalloc), and process RSS peak for
+representative pipeline shapes. Run on main (before) and on the feature branch
+(after), then compare JSON outputs.
+
+Usage:
+    uv run python benchmarks/bench_issue_9a.py --scale 500 --output artifacts/before.json
+    uv run python benchmarks/bench_issue_9a.py compare artifacts/before.json artifacts/after.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import resource
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, etl, get
+from etielle.fluent import PipelineBuilder
+
+Base = declarative_base()
+
+
+class BenchUser(Base):
+    __tablename__ = "bench_users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class BenchPost(Base):
+    __tablename__ = "bench_posts"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    user_id = Column(Integer, ForeignKey("bench_users.id"))
+    user = relationship("BenchUser", back_populates="posts")
+
+
+BenchUser.posts = relationship("BenchPost", back_populates="user")
+
+
+class BenchTag(Base):
+    __tablename__ = "bench_tags"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class BenchItem(Base):
+    __tablename__ = "bench_items"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    tag_id = Column(Integer, ForeignKey("bench_tags.id"))
+
+
+@dataclass
+class BenchResult:
+    name: str
+    scale: int
+    wall_seconds: float
+    heap_peak_bytes: int
+    rss_peak_kb: int
+    tables_mapped: int
+    rows_mapped: int
+    result_table_count: int
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "scale": self.scale,
+            "wall_seconds": self.wall_seconds,
+            "heap_peak_bytes": self.heap_peak_bytes,
+            "rss_peak_kb": self.rss_peak_kb,
+            "tables_mapped": self.tables_mapped,
+            "rows_mapped": self.rows_mapped,
+            "result_table_count": self.result_table_count,
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class BenchReport:
+    etielle_version: str
+    python_version: str
+    scale: int
+    load_mode: bool
+    results: list[BenchResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        import etielle
+
+        return {
+            "etielle_version": etielle.__version__ if hasattr(etielle, "__version__") else "unknown",
+            "python_version": sys.version,
+            "scale": self.scale,
+            "load_mode": self.load_mode,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+def _rss_kb() -> int:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    rss = usage.ru_maxrss
+    if sys.platform == "darwin":
+        return rss // 1024
+    return rss
+
+
+def _run_bench(name: str, scale: int, fn: Callable[[], Any]) -> BenchResult:
+    gc.collect()
+    tracemalloc.start()
+    rss_before = _rss_kb()
+    t0 = time.perf_counter()
+    result = fn()
+    wall = time.perf_counter() - t0
+    _, heap_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_peak = max(_rss_kb(), rss_before)
+
+    tables_mapped = 0
+    rows_mapped = 0
+    result_table_count = 0
+    notes = ""
+
+    if hasattr(result, "stats"):
+        stats = result.stats
+        tables_mapped = len(stats)
+        rows_mapped = sum(s.mapped for s in stats.values())
+    if hasattr(result, "tables"):
+        try:
+            result_table_count = len(list(result.tables.keys()))
+        except Exception:
+            result_table_count = 0
+
+    return BenchResult(
+        name=name,
+        scale=scale,
+        wall_seconds=wall,
+        heap_peak_bytes=heap_peak,
+        rss_peak_kb=rss_peak,
+        tables_mapped=tables_mapped,
+        rows_mapped=rows_mapped,
+        result_table_count=result_table_count,
+        notes=notes,
+    )
+
+
+def _no_relationships_data(scale: int) -> dict[str, Any]:
+    return {
+        f"table_{i}": [{"id": j, "value": f"v{i}_{j}"} for j in range(scale)]
+        for i in range(10)
+    }
+
+
+def _many_components_data(scale: int) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    for i in range(scale):
+        data[f"users_{i}"] = [{"id": 1, "name": f"user_{i}"}]
+        data[f"posts_{i}"] = [{"id": 1, "title": f"post_{i}", "user_id": 1}]
+    return data
+
+
+def _single_component_data(scale: int) -> dict[str, Any]:
+    users = [{"id": i, "name": f"user_{i}"} for i in range(scale)]
+    posts = [{"id": i, "title": f"post_{i}", "user_id": i % scale} for i in range(scale * 2)]
+    return {"users": users, "posts": posts}
+
+
+def _eager_dimension_data(scale: int) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "tags": [{"id": t, "name": f"tag_{t}"} for t in range(5)],
+    }
+    for i in range(scale):
+        data[f"items_{i}"] = [{"id": 1, "name": f"item_{i}", "tag_id": i % 5}]
+    return data
+
+
+def _build_no_relationships(scale: int) -> PipelineBuilder:
+    builder = etl(_no_relationships_data(scale))
+    for i in range(10):
+        builder = (
+            builder.goto_root()
+            .goto(f"table_{i}")
+            .each()
+            .map_to(
+                table=f"rows_{i}",
+                fields=[
+                    Field("id", get("id")),
+                    Field("value", get("value")),
+                ],
+            )
+        )
+    return builder
+
+
+def _build_many_components(scale: int) -> PipelineBuilder:
+    builder = etl(_many_components_data(scale))
+    for i in range(scale):
+        builder = (
+            builder.goto_root()
+            .goto(f"users_{i}")
+            .each()
+            .map_to(
+                table=f"users_{i}",
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto(f"posts_{i}")
+            .each()
+            .map_to(
+                table=f"posts_{i}",
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(f"users_{i}", by={"user_id": "id"})
+        )
+    return builder
+
+
+def _build_single_component(scale: int) -> PipelineBuilder:
+    return (
+        etl(_single_component_data(scale))
+        .goto("users")
+        .each()
+        .map_to(
+            table=BenchUser,
+            fields=[
+                Field("name", get("name")),
+                TempField("id", get("id")),
+            ],
+        )
+        .goto_root()
+        .goto("posts")
+        .each()
+        .map_to(
+            table=BenchPost,
+            fields=[
+                Field("title", get("title")),
+                TempField("id", get("id")),
+                TempField("user_id", get("user_id")),
+            ],
+        )
+        .link_to(BenchUser, by={"user_id": "id"})
+    )
+
+
+def _build_eager_dimension(scale: int, *, use_eager: bool) -> PipelineBuilder:
+    builder = etl(_eager_dimension_data(scale))
+    builder = (
+        builder.goto("tags")
+        .each()
+        .map_to(
+            table=BenchTag,
+            fields=[
+                Field("name", get("name")),
+                TempField("id", get("id")),
+            ],
+        )
+    )
+    if use_eager:
+        builder = builder.load_eager(BenchTag)
+    for i in range(scale):
+        builder = (
+            builder.goto_root()
+            .goto(f"items_{i}")
+            .each()
+            .map_to(
+                table=f"items_{i}",
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(BenchTag, by={"tag_id": "id"})
+        )
+    return builder
+
+
+def run_benchmarks(scale: int, *, load_mode: bool) -> BenchReport:
+    import etielle
+
+    report = BenchReport(
+        etielle_version=getattr(etielle, "__version__", "unknown"),
+        python_version=sys.version,
+        scale=scale,
+        load_mode=load_mode,
+    )
+
+    session = None
+    if load_mode:
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+    def _execute(builder: PipelineBuilder):
+        if load_mode and session is not None:
+            return builder.load(session).run()
+        return builder.run()
+
+    scenarios: list[tuple[str, Callable[[], PipelineBuilder]]] = [
+        ("no_relationships", lambda: _build_no_relationships(scale)),
+        ("many_components", lambda: _build_many_components(min(scale, 100))),
+        ("single_component", lambda: _build_single_component(scale)),
+        (
+            "eager_dimension_without_eager",
+            lambda: _build_eager_dimension(min(scale, 100), use_eager=False),
+        ),
+        (
+            "eager_dimension_with_eager",
+            lambda: _build_eager_dimension(min(scale, 100), use_eager=True),
+        ),
+    ]
+
+    for name, build_fn in scenarios:
+        builder = build_fn()
+
+        def _run(builder=builder):
+            return _execute(builder)
+
+        report.results.append(_run_bench(name, scale, _run))
+
+    if session is not None:
+        session.close()
+
+    return report
+
+
+def _compare_reports(before: dict[str, Any], after: dict[str, Any]) -> str:
+    lines = [
+        "# Issue 9A benchmark comparison",
+        "",
+        f"Scale: {before.get('scale')} | Load mode: {before.get('load_mode')}",
+        "",
+        "| Scenario | Before RSS (KB) | After RSS (KB) | RSS Δ | Before time (s) | After time (s) | Time Δ |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    after_by_name = {r["name"]: r for r in after.get("results", [])}
+    for row in before.get("results", []):
+        name = row["name"]
+        aft = after_by_name.get(name, {})
+        rss_b = row.get("rss_peak_kb", 0)
+        rss_a = aft.get("rss_peak_kb", 0)
+        time_b = row.get("wall_seconds", 0)
+        time_a = aft.get("wall_seconds", 0)
+        rss_delta = ((rss_a - rss_b) / rss_b * 100) if rss_b else 0
+        time_delta = ((time_a - time_b) / time_b * 100) if time_b else 0
+        lines.append(
+            f"| {name} | {rss_b} | {rss_a} | {rss_delta:+.1f}% | "
+            f"{time_b:.3f} | {time_a:.3f} | {time_delta:+.1f}% |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark issue 9A component flush/evict")
+    sub = parser.add_subparsers(dest="command")
+
+    run_p = sub.add_parser("run", help="Run benchmarks")
+    run_p.add_argument("--scale", type=int, default=500)
+    run_p.add_argument("--output", type=Path, required=True)
+    run_p.add_argument("--load", action="store_true", help="Use load(session).run() mode")
+
+    cmp_p = sub.add_parser("compare", help="Compare two JSON reports")
+    cmp_p.add_argument("before", type=Path)
+    cmp_p.add_argument("after", type=Path)
+    cmp_p.add_argument("--markdown", type=Path, help="Write markdown comparison table")
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        report = run_benchmarks(args.scale, load_mode=args.load)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report.to_dict(), indent=2))
+        print(f"Wrote {args.output}")
+        return
+
+    if args.command == "compare":
+        before = json.loads(args.before.read_text())
+        after = json.loads(args.after.read_text())
+        md = _compare_reports(before, after)
+        if args.markdown:
+            args.markdown.write_text(md)
+            print(f"Wrote {args.markdown}")
+        else:
+            print(md)
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -10,12 +10,12 @@ title: "Database Loading: Persisting with load().run()"
 
 The `load(session)` method configures your pipeline to persist results to a database. When combined with `run()`, it:
 
-1. Builds all instances in memory
-2. Binds relationships
+1. Maps instances by relationship component
+2. Binds relationships within each component
 3. Adds instances to the session
-4. Flushes (but does NOT commit)
+4. Flushes each component and evicts flushed instances from the result
 
-You control the transaction (commit/rollback).
+`load().run()` returns **stats and errors**, not flushed instances in `result.tables`. Use `session.query()` or equivalent to read persisted rows. You control the transaction (commit/rollback).
 
 ```python
 from etielle import etl, Field, TempField, get
@@ -229,6 +229,33 @@ with Session(engine) as session:
     user = session.get(User, "u1")
     print(f"{user.name} has {len(user.posts)} posts")
 ```
+
+## Component-Scoped Flushing and Memory
+
+Pipelines with relationships are executed as independent **relationship components** (weakly connected subgraphs of the `link_to`/`backlink` graph). Each component is mapped, bound, flushed, and evicted before the next component runs. This bounds peak accumulator memory to the largest component instead of the entire dataset.
+
+Tables with no relationship edges are batched into a single mapping pass for efficiency.
+
+## Shared Tables with `load_eager()`
+
+When a shared dimension table (e.g. `tags`) is referenced by many independent subgraphs, the relationship graph collapses into one giant component and the memory win vanishes. Mark small shared tables as eager so they are loaded once and kept resident while other components are processed:
+
+```python
+result = (
+    etl(data)
+    .goto("tags").each()
+    .map_to(table=Tag, fields=[...])
+    .load_eager(Tag)          # resident across all components
+    .goto_root()
+    .goto("items").each()
+    .map_to(table=Item, fields=[...])
+    .link_to(Tag, by={"tag_id": "id"})
+    .load(session)
+    .run()
+)
+```
+
+`load_eager()` requires an explicit preceding `map_to()` for the same table.
 
 ## Upsert Behavior
 

--- a/docs/introduction-to-etl.qmd
+++ b/docs/introduction-to-etl.qmd
@@ -202,8 +202,9 @@ Learn more: [Transforms](transforms.qmd), [Mapping Tables](mapping.qmd), [Relati
 
 **Key features**:
 - `load(session)`: Configure database session
-- `run()`: Execute pipeline and flush to database
-- One-shot flushing for performance
+- `run()`: Execute pipeline and flush to database by relationship component
+- `load_eager(table)`: Keep shared dimension tables resident across components
+- Flushed instances are not retained in `PipelineResult.tables` (use stats/errors or query the DB)
 - You control the transaction (commit/rollback)
 
 **Example**:

--- a/etielle/__init__.py
+++ b/etielle/__init__.py
@@ -1,3 +1,12 @@
+"""etielle - declarative JSON-to-relational mapping."""
+
+try:
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("etielle")
+except Exception:
+    __version__ = "0.0.0.dev"
+
 from .core import (
     Context,
     Field as CoreField,  # Renamed to avoid conflict with fluent.Field

--- a/etielle/core.py
+++ b/etielle/core.py
@@ -246,6 +246,7 @@ class MappingResult(Generic[T]):
     - finalize_errors: per-key errors recorded while finalizing/validating instances
     - stats: simple counters to aid diagnostics (keys: num_instances, num_update_errors, num_finalize_errors)
     - indices: secondary indices for relationship linking {field_name: {value: instance}}
+    - lookup_values: per-key field values captured during mapping for relationship binding
     """
 
     instances: Dict[Tuple[Any, ...], T]
@@ -253,3 +254,4 @@ class MappingResult(Generic[T]):
     finalize_errors: Dict[Tuple[Any, ...], List[str]]
     stats: Dict[str, int]
     indices: Dict[str, Dict[Any, T]] = field(default_factory=dict)
+    lookup_values: Dict[Tuple[Any, ...], Dict[str, Any]] = field(default_factory=dict)

--- a/etielle/executor.py
+++ b/etielle/executor.py
@@ -5,6 +5,8 @@ from .transforms import _iter_nodes, _resolve_path
 from collections.abc import Mapping, Sequence, Iterable
 from .instances import InstanceEmit, resolve_field_name_for_builder
 
+KeyTuple = Tuple[Any, ...]
+
 # -----------------------------
 # Executor
 # -----------------------------
@@ -166,11 +168,51 @@ def _iter_traversal_nodes(
                 yield ctx
 
 
+
+def _compute_composite_key(
+    emit: Any,
+    ctx: Context,
+    auto_key_counters: Dict[str, int],
+) -> KeyTuple | None:
+    """Compute composite join key for an emit, matching mapping semantics."""
+    if emit.join_keys:
+        key_parts: List[Any] = [tr(ctx) for tr in emit.join_keys]
+        if any(part is None or part == "" for part in key_parts):
+            return None
+        return tuple(key_parts)
+
+    table_name = emit.table
+    counter = auto_key_counters.get(table_name, 0)
+    auto_key_counters[table_name] = counter + 1
+    return (f"__auto_{counter}__",)
+
+
+def _capture_lookup_values(
+    emit: Any,
+    ctx: Context,
+    composite_key: KeyTuple,
+    field_captures: Dict[str, Dict[str, Any]] | None,
+    lookup_store: Dict[str, Dict[KeyTuple, Dict[str, Any]]],
+) -> None:
+    """Capture relationship lookup field values during the primary mapping pass."""
+    if not field_captures:
+        return
+    captures = field_captures.get(emit.table)
+    if not captures:
+        return
+    bucket = lookup_store.setdefault(emit.table, {}).setdefault(composite_key, {})
+    for field_name, transform in captures.items():
+        bucket[field_name] = transform(ctx)
+
+
 def run_mapping(
     root: Any,
     spec: MappingSpec,
     linkable_fields: Dict[str, set[str]] | None = None,
     context_slots: Dict[str, Any] | None = None,
+    field_captures: Dict[str, Dict[str, Any]] | None = None,
+    *,
+    table_filter: set[str] | None = None,
 ) -> Dict[str, MappingResult[Any]]:
     """
     Execute mapping spec against root JSON, returning rows per table.
@@ -186,6 +228,9 @@ def run_mapping(
         spec: The mapping specification
         linkable_fields: Dict mapping table name to set of field names used in link_to
         context_slots: Optional dict to inject into context.slots (e.g., for indices)
+        field_captures: Optional dict mapping table -> {field_name: transform} to
+            capture during mapping for relationship binding (single-pass).
+        table_filter: If set, only emit to tables in this set.
     """
     if linkable_fields is None:
         linkable_fields = {}
@@ -199,23 +244,21 @@ def run_mapping(
     # Auto-generated key counter for instances without join_on
     auto_key_counters: Dict[str, int] = {}
 
+    # Per-table lookup values captured during mapping {table: {key: {field: value}}}
+    lookup_stores: Dict[str, Dict[KeyTuple, Dict[str, Any]]] = {}
+
     for traversal in spec.traversals:
         for ctx in _iter_traversal_nodes(root, traversal, context_slots):
             for emit in traversal.emits:
-                # Compute join key
-                if emit.join_keys:
-                    # Join keys specified - compute composite key
-                    key_parts: List[Any] = [tr(ctx) for tr in emit.join_keys]
-                    if any(part is None or part == "" for part in key_parts):
-                        continue
-                    composite_key = tuple(key_parts)
-                else:
-                    # No join keys - use auto-generated unique key
-                    # This allows each iteration to create a distinct instance
-                    table_name = emit.table
-                    counter = auto_key_counters.get(table_name, 0)
-                    composite_key = (f"__auto_{counter}__",)
-                    auto_key_counters[table_name] = counter + 1
+                if table_filter is not None and emit.table not in table_filter:
+                    continue
+                composite_key = _compute_composite_key(emit, ctx, auto_key_counters)
+                if composite_key is None:
+                    continue
+
+                _capture_lookup_values(
+                    emit, ctx, composite_key, field_captures, lookup_stores
+                )
 
                 # Branch by emit type
                 if isinstance(emit, TableEmit):
@@ -331,6 +374,7 @@ def run_mapping(
                 "num_update_errors": 0,
                 "num_finalize_errors": 0,
             },
+            lookup_values=lookup_stores.get(table, {}),
         )
 
     # 2) Instance tables (builders)
@@ -379,6 +423,7 @@ def run_mapping(
                 "num_finalize_errors": sum(len(v) for v in fin_errors.values()),
             },
             indices=indices,
+            lookup_values=lookup_stores.get(table, {}),
         )
 
     return outputs

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -354,6 +354,7 @@ class PipelineBuilder:
         self._index_builds: list[dict[str, Any]] = []
         # Session for loading
         self._session: Any | None = None
+        self._eager_tables: set[str] = set()
         # Supabase-specific options
         self._upsert: bool = False
         self._upsert_on: dict[str, str | list[str]] | None = None
@@ -681,10 +682,10 @@ class PipelineBuilder:
         """Configure database session or client for persistence.
 
         When load() is called before run(), the pipeline will:
-        1. Build all instances in memory
-        2. Bind relationships
+        1. Map instances by relationship component
+        2. Bind relationships within each component
         3. Add instances to the session (SQLAlchemy) or insert to database (Supabase)
-        4. Flush (but not commit for SQLAlchemy)
+        4. Flush and evict each component (instances are not retained in PipelineResult)
 
         The caller controls the transaction (commit/rollback) for SQLAlchemy.
 
@@ -737,6 +738,37 @@ class PipelineBuilder:
         self._upsert_on = upsert_on
         self._batch_size = batch_size
         return self
+
+    def load_eager(self, table: str | type) -> PipelineBuilder:
+        """Mark a table as eagerly loaded and kept resident across components.
+
+        Shared dimension tables referenced by many independent subgraphs should
+        be loaded eagerly so component partitioning can proceed without collapsing
+        the entire graph into one component.
+
+        Args:
+            table: Model class or table name string declared via map_to().
+
+        Returns:
+            Self for method chaining.
+
+        Example:
+            etl(data)
+            .goto("tags").each()
+            .map_to(table=Tag, fields=[...])
+            .load_eager(Tag)
+            .goto_root()
+            ...
+        """
+        table_name = self._resolve_table_name(table)
+        self._eager_tables.add(table_name)
+        return self
+
+    @staticmethod
+    def _resolve_table_name(table: str | type) -> str:
+        if isinstance(table, str):
+            return table
+        return getattr(table, "__tablename__", table.__name__.lower())
 
     def _is_supabase_client(self, obj: Any) -> bool:
         """Check if the object is a Supabase client."""
@@ -1110,6 +1142,358 @@ class PipelineBuilder:
                     linkable.setdefault(parent_table, set()).add(parent_field)
         return linkable
 
+    def _get_captured_fields(self) -> dict[str, set[str]]:
+        """Fields whose values must be captured during mapping for relationship binding."""
+        captured: dict[str, set[str]] = {}
+        for rel in self._relationships:
+            if rel.get("type") == "backlink":
+                parent_table = rel["parent_table"]
+                child_table = rel["child_table"]
+                for parent_field in rel["by"].keys():
+                    captured.setdefault(parent_table, set()).add(parent_field)
+                for child_field in rel["by"].values():
+                    captured.setdefault(child_table, set()).add(child_field)
+            else:
+                child_table = rel["child_table"]
+                parent_table = rel["parent_table"]
+                for child_field in rel["by"].keys():
+                    captured.setdefault(child_table, set()).add(child_field)
+                for parent_field in rel["by"].values():
+                    captured.setdefault(parent_table, set()).add(parent_field)
+        return captured
+
+    def _build_field_captures(
+        self, captured_fields: dict[str, set[str]]
+    ) -> dict[str, dict[Any, Any]]:
+        """Map captured field names to transforms from emission definitions."""
+        if not captured_fields:
+            return {}
+        field_captures: dict[str, dict[Any, Any]] = {}
+        for emission in self._emissions:
+            table = emission["table"]
+            needed = captured_fields.get(table)
+            if not needed:
+                continue
+            for fld in emission["fields"]:
+                if fld.name in needed:
+                    field_captures.setdefault(table, {})[fld.name] = fld.transform
+        return field_captures
+
+    def _validate_eager_tables(
+        self,
+        eager_tables: set[str],
+        dep_graph: dict[str, set[str]],
+        emission_tables: set[str],
+    ) -> None:
+        """Validate load_eager configuration."""
+        for table in eager_tables:
+            if table not in emission_tables:
+                raise ValueError(
+                    f"load_eager({table!r}) requires a preceding map_to() for that table"
+                )
+
+        for rel in self._relationships:
+            if rel.get("type") != "backlink":
+                continue
+            parent = rel["parent_table"]
+            child = rel["child_table"]
+            parent_eager = parent in eager_tables
+            child_eager = child in eager_tables
+            if parent_eager != child_eager:
+                raise ValueError(
+                    "backlink() cannot cross eager/non-eager boundaries; "
+                    f"mark both {parent!r} and {child!r} as load_eager or neither"
+                )
+
+        for child, parents in dep_graph.items():
+            if child not in eager_tables:
+                continue
+            non_eager_parents = parents - eager_tables
+            if non_eager_parents:
+                raise ValueError(
+                    f"load_eager table {child!r} cannot depend on non-eager "
+                    f"parent(s): {sorted(non_eager_parents)}"
+                )
+
+    def _build_specs_for_emissions(
+        self, emissions: list[dict[str, Any]]
+    ) -> list[Any]:
+        """Build TraversalSpec list for a subset of emissions."""
+        original = self._emissions
+        self._emissions = emissions
+        try:
+            return self._build_traversal_specs()
+        finally:
+            self._emissions = original
+
+    def _merge_mapping_results(self, existing: Any, incoming: Any) -> None:
+        """Merge incoming MappingResult into existing in place."""
+        for key, row in incoming.instances.items():
+            if key in existing.instances:
+                if hasattr(existing.instances[key], "update"):
+                    existing.instances[key].update(row)
+                elif hasattr(existing.instances[key], "__dict__"):
+                    source = row.__dict__ if hasattr(row, "__dict__") else row
+                    for k, v in source.items():
+                        setattr(existing.instances[key], k, v)
+            else:
+                existing.instances[key] = row
+        for key, msgs in incoming.update_errors.items():
+            existing.update_errors.setdefault(key, []).extend(msgs)
+        for key, msgs in incoming.finalize_errors.items():
+            existing.finalize_errors.setdefault(key, []).extend(msgs)
+        for field_name, index in incoming.indices.items():
+            existing.indices.setdefault(field_name, {}).update(index)
+        existing.lookup_values.update(incoming.lookup_values)
+
+    def _map_tables(
+        self,
+        target_tables: set[str],
+        linkable_fields: dict[str, set[str]],
+        field_captures: dict[str, dict[Any, Any]],
+    ) -> dict[str, Any]:
+        """Run mapping for emissions targeting the given tables."""
+        from etielle.core import MappingSpec
+        from etielle.executor import run_mapping
+
+        emissions_by_root: dict[int, list[dict[str, Any]]] = {}
+        for emission in self._emissions:
+            if emission["table"] not in target_tables:
+                continue
+            emissions_by_root.setdefault(emission["root_index"], []).append(emission)
+
+        all_raw_results: dict[str, Any] = {}
+        for root_idx in sorted(emissions_by_root.keys()):
+            emissions = emissions_by_root[root_idx]
+            specs = self._build_specs_for_emissions(emissions)
+            mapping_spec = MappingSpec(traversals=tuple(specs))
+            root = self._roots[root_idx]
+            raw_results = run_mapping(
+                root,
+                mapping_spec,
+                linkable_fields=linkable_fields,
+                context_slots={"__indices__": self._indices},
+                field_captures=field_captures,
+                table_filter=target_tables,
+            )
+            for table_name, mapping_result in raw_results.items():
+                if table_name not in all_raw_results:
+                    all_raw_results[table_name] = mapping_result
+                else:
+                    self._merge_mapping_results(
+                        all_raw_results[table_name], mapping_result
+                    )
+        return all_raw_results
+
+    def _record_mapping_stats(
+        self,
+        raw_results: dict[str, Any],
+        stats: dict[str, TableStats],
+        on_event: TelemetryCallback | None,
+    ) -> None:
+        """Emit mapping telemetry and update stats for mapped tables."""
+        for table_name, mapping_result in raw_results.items():
+            if table_name in stats:
+                continue
+            _emit(MapStarted(table=table_name), on_event)
+            error_count = (
+                len(mapping_result.update_errors)
+                + len(mapping_result.finalize_errors)
+            )
+            instance_count = len(mapping_result.instances)
+            _emit(
+                MapCompleted(
+                    table=table_name,
+                    count=instance_count,
+                    error_count=error_count,
+                ),
+                on_event,
+            )
+            stats[table_name] = TableStats(
+                mapped=instance_count,
+                errors=error_count,
+                inserted=0,
+                failed=0,
+            )
+
+    def _collect_errors(
+        self, raw_results: dict[str, Any]
+    ) -> dict[str, dict[tuple[Any, ...], list[str]]]:
+        errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
+        for table_name, mapping_result in raw_results.items():
+            all_errors: dict[tuple[Any, ...], list[str]] = {}
+            for key, msgs in mapping_result.update_errors.items():
+                all_errors.setdefault(key, []).extend(msgs)
+            for key, msgs in mapping_result.finalize_errors.items():
+                all_errors.setdefault(key, []).extend(msgs)
+            if all_errors:
+                errors[table_name] = all_errors
+        return errors
+
+    def _bind_relationships_in_scope(
+        self,
+        raw_results: dict[str, Any],
+        link_to_rels: list[dict[str, Any]],
+        backlink_rels: list[dict[str, Any]],
+        scope_tables: set[str],
+    ) -> None:
+        """Bind relationships whose endpoints are within scope_tables."""
+        from etielle.relationships import bind_relationships_via_index, bind_backlinks
+
+        scoped_link_to = [
+            rel for rel in link_to_rels if rel["child_table"] in scope_tables
+        ]
+        scoped_backlinks = [
+            rel
+            for rel in backlink_rels
+            if rel["parent_table"] in scope_tables
+            and rel["child_table"] in scope_tables
+        ]
+
+        child_lookup_values = {
+            table: mr.lookup_values for table, mr in raw_results.items()
+        }
+        parent_lookup_values = child_lookup_values
+
+        if scoped_link_to:
+            bind_relationships_via_index(
+                raw_results,
+                scoped_link_to,
+                child_lookup_values,
+                fail_on_missing=False,
+            )
+        if scoped_backlinks:
+            bind_backlinks(
+                raw_results,
+                scoped_backlinks,
+                parent_lookup_values,
+                fail_on_missing=False,
+            )
+
+    def _flush_sqlalchemy_scope(
+        self,
+        scope_tables: set[str],
+        raw_results: dict[str, Any],
+        dep_graph: dict[str, set[str]],
+        link_to_rels: list[dict[str, Any]],
+        backlink_rels: list[dict[str, Any]],
+        stats: dict[str, TableStats],
+        on_event: TelemetryCallback | None,
+    ) -> None:
+        """Flush tables in scope to SQLAlchemy session in dependency order."""
+        from etielle.utils import topological_sort
+
+        tables = {
+            t: dict(raw_results[t].instances)
+            for t in scope_tables
+            if t in raw_results
+        }
+        flush_order = topological_sort(dep_graph, set(tables.keys()))
+
+        pending_bindings: dict[str, list[tuple[int, str]]] = {}
+        for idx, rel in enumerate(link_to_rels):
+            if rel.get("type") == "backlink":
+                continue
+            if rel["child_table"] in scope_tables:
+                pending_bindings.setdefault(rel["child_table"], []).append(
+                    (idx, rel["parent_table"])
+                )
+
+        for table_name in flush_order:
+            if table_name not in tables:
+                continue
+
+            row_count = len(tables[table_name])
+            _emit(FlushStarted(table=table_name, count=row_count), on_event)
+
+            for _key, instance in tables[table_name].items():
+                if not isinstance(instance, dict):
+                    self._session.add(instance)
+
+            for idx, parent_table in pending_bindings.get(table_name, []):
+                if parent_table not in raw_results:
+                    continue
+                rel = link_to_rels[idx]
+                parent_result = raw_results[parent_table]
+                child_result = raw_results[table_name]
+                attr_name = (
+                    parent_table.rstrip("s")
+                    if parent_table.endswith("s")
+                    else parent_table
+                )
+                lookup_values = child_result.lookup_values
+
+                for child_key, child_obj in child_result.instances.items():
+                    if isinstance(child_obj, dict):
+                        continue
+                    child_values = lookup_values.get(child_key, {})
+                    for child_field, parent_field in rel["by"].items():
+                        lookup_value = child_values.get(child_field)
+                        if lookup_value is None:
+                            continue
+                        parent_index = parent_result.indices.get(parent_field, {})
+                        parent_obj = parent_index.get(lookup_value)
+                        if parent_obj is not None:
+                            setattr(child_obj, attr_name, parent_obj)
+
+            try:
+                self._session.flush()
+                _emit(
+                    FlushCompleted(
+                        table=table_name,
+                        inserted=row_count,
+                        failed=0,
+                        batch_num=1,
+                        batch_total=1,
+                        upsert=False,
+                    ),
+                    on_event,
+                )
+                if table_name in stats:
+                    stats[table_name] = TableStats(
+                        mapped=stats[table_name].mapped,
+                        errors=stats[table_name].errors,
+                        inserted=row_count,
+                        failed=0,
+                    )
+            except Exception as e:
+                _emit(
+                    FlushFailed(
+                        table=table_name,
+                        error=str(e),
+                        affected_count=row_count,
+                    ),
+                    on_event,
+                )
+                if table_name in stats:
+                    stats[table_name] = TableStats(
+                        mapped=stats[table_name].mapped,
+                        errors=stats[table_name].errors,
+                        inserted=0,
+                        failed=row_count,
+                    )
+                raise
+
+        scoped_backlinks = [
+            rel
+            for rel in backlink_rels
+            if rel["parent_table"] in scope_tables
+            and rel["child_table"] in scope_tables
+        ]
+        if scoped_backlinks:
+            from etielle.relationships import bind_backlinks
+
+            parent_lookup_values = {
+                table: mr.lookup_values for table, mr in raw_results.items()
+            }
+            bind_backlinks(
+                raw_results,
+                scoped_backlinks,
+                parent_lookup_values,
+                fail_on_missing=False,
+            )
+            self._session.flush()
+
     def run(
         self,
         *,
@@ -1125,407 +1509,223 @@ class PipelineBuilder:
                 FlushFailed events during pipeline execution.
 
         Returns:
-            PipelineResult with tables, errors, and stats.
+            PipelineResult with tables, errors, and stats. When load() was
+            configured, flushed instances are not retained in result.tables
+            (stats and errors are always returned).
         """
-        from etielle.core import MappingSpec, TraversalSpec
-        from etielle.executor import run_mapping, _iter_traversal_nodes
+        from etielle.core import TraversalSpec
+        from etielle.executor import _iter_traversal_nodes
+        from etielle.utils import partition_components, topological_sort
 
         # Build indices from traversal specs before main execution
         for build in self._index_builds:
             index_name = build["name"]
             key_transform = build["key"]
             value_transform = build["value"]
-
-            # Determine the traversal path from iteration points
-            # iteration_points contains the path at each .each() call
             iteration_points = build["iteration_points"]
 
             if not iteration_points:
-                # No iterations - skip this build
                 continue
 
-            # For nested iterations, outer path is first iteration point
-            # inner path is relative from there to the final path
             outer_path = iteration_points[0]
-
             inner_path = None
             if len(iteration_points) > 1:
-                # Multiple iterations - compute inner path
-                # Inner path is relative to outer path
                 inner_start = len(outer_path)
                 full_path = build["path"]
                 if inner_start < len(full_path):
                     inner_path = full_path[inner_start:]
 
-            # Create traversal spec for index building
             temp_spec = TraversalSpec(
                 path=tuple(outer_path),
                 mode="auto",
                 inner_path=tuple(inner_path) if inner_path else None,
                 inner_mode="auto",
-                emits=(),  # No emissions, just traversing
+                emits=(),
             )
 
             root = self._roots[build["root_index"]]
             index_data: dict[Any, Any] = {}
-
-            # Traverse and populate index
             for ctx in _iter_traversal_nodes(root, temp_spec):
                 k = key_transform(ctx)
                 v = value_transform(ctx)
                 if k is not None:
                     index_data[k] = v
-
             self._indices[index_name] = index_data
 
-        # Extract linkable fields from link_to declarations
         linkable_fields = self._get_linkable_fields()
+        captured_fields = self._get_captured_fields()
+        field_captures = self._build_field_captures(captured_fields)
 
-        # Group emissions by root index
-        emissions_by_root: dict[int, list[dict[str, Any]]] = {}
-        for emission in self._emissions:
-            root_idx = emission["root_index"]
-            emissions_by_root.setdefault(root_idx, []).append(emission)
+        emission_tables = {e["table"] for e in self._emissions}
+        eager_tables = set(self._eager_tables)
+        dep_graph = self._build_dependency_graph()
+        self._validate_eager_tables(eager_tables, dep_graph, emission_tables)
 
-        # Execute for each root and merge results
-        all_raw_results: dict[str, Any] = {}
-
-        for root_idx in sorted(emissions_by_root.keys()):
-            emissions = emissions_by_root[root_idx]
-            root = self._roots[root_idx]
-
-            # Build specs for this root's emissions only
-            specs = []
-            for emission in emissions:
-                # Temporarily set self._emissions to only this emission's list
-                # to reuse _build_traversal_specs logic
-                original_emissions = self._emissions
-                self._emissions = [emission]
-                emission_specs = self._build_traversal_specs()
-                self._emissions = original_emissions
-                specs.extend(emission_specs)
-
-            mapping_spec = MappingSpec(traversals=tuple(specs))
-            raw_results = run_mapping(
-                root,
-                mapping_spec,
-                linkable_fields=linkable_fields,
-                context_slots={"__indices__": self._indices},
-            )
-
-            # Merge into combined results
-            for table_name, mapping_result in raw_results.items():
-                if table_name not in all_raw_results:
-                    all_raw_results[table_name] = mapping_result
-                else:
-                    # Merge instances from this root with existing ones
-                    existing = all_raw_results[table_name]
-                    for key, row in mapping_result.instances.items():
-                        if key in existing.instances:
-                            # Update existing row with new fields
-                            if hasattr(existing.instances[key], 'update'):
-                                existing.instances[key].update(row)
-                            elif hasattr(existing.instances[key], '__dict__'):
-                                # For object instances, merge attributes
-                                for k, v in (row.__dict__ if hasattr(row, '__dict__') else row).items():
-                                    setattr(existing.instances[key], k, v)
-                        else:
-                            existing.instances[key] = row
-                    # Merge errors
-                    for key, msgs in mapping_result.update_errors.items():
-                        existing.update_errors.setdefault(key, []).extend(msgs)
-                    for key, msgs in mapping_result.finalize_errors.items():
-                        existing.finalize_errors.setdefault(key, []).extend(msgs)
-
-        raw_results = all_raw_results
-
-        # Emit mapping events and initialize stats
-        stats: dict[str, TableStats] = {}
-        for table_name, mapping_result in raw_results.items():
-            _emit(MapStarted(table=table_name), on_event)
-            error_count = (
-                len(mapping_result.update_errors) +
-                len(mapping_result.finalize_errors)
-            )
-            instance_count = len(mapping_result.instances)
-            _emit(
-                MapCompleted(
-                    table=table_name,
-                    count=instance_count,
-                    error_count=error_count,
-                ),
-                on_event,
-            )
-            stats[table_name] = TableStats(
-                mapped=instance_count,
-                errors=error_count,
-                inserted=0,  # Updated during flush
-                failed=0,
-            )
-
-        # Handle relationship binding and staged flushing
-        rel_specs: list[Any] = []
-        child_lookup_values: dict[str, dict[tuple[Any, ...], dict[str, Any]]] = {}
-        backlink_lookup_values: dict[str, dict[tuple[Any, ...], dict[str, Any]]] = {}
-
-        # Separate link_to (many-to-one) from backlink (many-to-many) relationships
         link_to_rels = [r for r in self._relationships if r.get("type") != "backlink"]
         backlink_rels = [r for r in self._relationships if r.get("type") == "backlink"]
 
-        if self._relationships:
-            from etielle.relationships import (
-                ManyToOneSpec,
-                bind_relationships_via_index,
-                compute_child_lookup_values,
-                bind_backlinks,
-                compute_backlink_lookup_values,
+        if self._session is not None and backlink_rels and self._is_supabase_client(
+            self._session
+        ):
+            raise ValueError(
+                "backlink() is not supported with Supabase. "
+                "backlink() relies on ORM-native many-to-many handling "
+                "which is only available with SQLAlchemy/SQLModel."
             )
 
-            # Build ManyToOneSpec objects from link_to relationships (not backlinks)
-            for rel in link_to_rels:
-                # Find the child emission to get the transforms for parent key computation
-                child_emission = self._emissions[rel["emission_index"]]
+        stats: dict[str, TableStats] = {}
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
+        result_tables: dict[str, dict[tuple[Any, ...], Any]] = {}
+        result_raw_results: dict[str, Any] | None = {} if self._session is None else None
+        retain_instances = self._session is None
 
-                # Build list of transforms that compute parent key from child context
-                child_to_parent_transforms = []
-                for child_field, parent_field in rel["by"].items():
-                    # Find the transform for this child field
-                    for f in child_emission["fields"]:
-                        if f.name == child_field:
-                            child_to_parent_transforms.append(f.transform)
-                            break
+        # Resident eager tables kept for cross-component binding
+        resident_results: dict[str, Any] = {}
 
-                # Infer attr name from parent table name (singular, lowercase)
-                # e.g., "users" -> "user", "posts" -> "post"
-                parent_table_name = rel["parent_table"]
-                attr_name = parent_table_name.rstrip("s") if parent_table_name.endswith("s") else parent_table_name
+        if eager_tables:
+            eager_results = self._map_tables(
+                eager_tables, linkable_fields, field_captures
+            )
+            self._record_mapping_stats(eager_results, stats, on_event)
+            resident_results.update(eager_results)
 
-                spec = ManyToOneSpec(
-                    child_table=rel["child_table"],
-                    parent_table=rel["parent_table"],
-                    attr=attr_name,
-                    child_to_parent_key=tuple(child_to_parent_transforms),
-                    required=False  # Don't fail on missing parents by default
-                )
-                rel_specs.append(spec)
+            bind_scope = set(eager_results.keys())
+            self._bind_relationships_in_scope(
+                resident_results, link_to_rels, backlink_rels, bind_scope
+            )
 
-            # Compute relationship keys by traversing all roots
-            # We need to rebuild the traversal specs for relationship computation
-            all_specs = []
-            for root_idx in sorted(emissions_by_root.keys()):
-                emissions = emissions_by_root[root_idx]
-                for emission in emissions:
-                    original_emissions = self._emissions
-                    self._emissions = [emission]
-                    emission_specs = self._build_traversal_specs()
-                    self._emissions = original_emissions
-                    all_specs.extend(emission_specs)
-
-            first_root = self._roots[0] if self._roots else {}
-
-            # Compute child lookup values for link_to relationships
-            if link_to_rels:
-                child_lookup_values = compute_child_lookup_values(
-                    first_root, all_specs, link_to_rels, self._emissions,
-                    context_slots={"__indices__": self._indices},
-                )
-
-            # Compute backlink lookup values for parent tables
-            if backlink_rels:
-                backlink_lookup_values = compute_backlink_lookup_values(
-                    first_root, all_specs, backlink_rels, self._emissions,
-                    context_slots={"__indices__": self._indices},
-                )
-
-            # If no session, bind all relationships now (non-DB use case)
-            # Use secondary indices for binding instead of join key computation
-            if self._session is None:
-                if link_to_rels:
-                    bind_relationships_via_index(
-                        raw_results, link_to_rels, child_lookup_values, fail_on_missing=False
+            if self._session is not None:
+                if self._is_supabase_client(self._session):
+                    if backlink_rels:
+                        raise ValueError(
+                            "backlink() is not supported with Supabase. "
+                            "backlink() relies on ORM-native many-to-many handling "
+                            "which is only available with SQLAlchemy/SQLModel."
+                        )
+                    child_lookup = {
+                        t: mr.lookup_values for t, mr in resident_results.items()
+                    }
+                    eager_tables_dict = {
+                        t: dict(mr.instances)
+                        for t, mr in resident_results.items()
+                    }
+                    eager_order = topological_sort(dep_graph, eager_tables)
+                    self._flush_to_supabase(
+                        eager_tables_dict,
+                        eager_order,
+                        child_lookup,
+                        stats,
+                        on_event,
                     )
-                if backlink_rels:
-                    bind_backlinks(
-                        raw_results, backlink_rels, backlink_lookup_values, fail_on_missing=False
-                    )
+                else:
+                    for rel in self._relationships:
+                        if rel.get("fk"):
+                            import warnings
 
-        # Convert to PipelineResult format
-        tables: dict[str, dict[tuple[Any, ...], Any]] = {}
-        errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
+                            warnings.warn(
+                                f"fk parameter on link_to() is only supported for Supabase. "
+                                f"Ignoring fk={rel['fk']} for {rel['child_table']} -> {rel['parent_table']}.",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                    self._flush_sqlalchemy_scope(
+                        eager_tables,
+                        resident_results,
+                        dep_graph,
+                        link_to_rels,
+                        backlink_rels,
+                        stats,
+                        on_event,
+                    )
+            elif retain_instances:
+                for table_name, mapping_result in eager_results.items():
+                    result_tables[table_name] = dict(mapping_result.instances)
+                if result_raw_results is not None:
+                    result_raw_results.update(eager_results)
+
+            eager_errors = self._collect_errors(eager_results)
+            for table_name, table_errors in eager_errors.items():
+                all_errors.setdefault(table_name, {}).update(table_errors)
+
+        components = partition_components(dep_graph, emission_tables, eager_tables)
+
+        for component in components:
+            component_results = self._map_tables(
+                component, linkable_fields, field_captures
+            )
+            self._record_mapping_stats(component_results, stats, on_event)
+
+            bind_context = {**resident_results, **component_results}
+            self._bind_relationships_in_scope(
+                bind_context, link_to_rels, backlink_rels, component
+            )
+
+            if self._session is not None:
+                if self._is_supabase_client(self._session):
+                    child_lookup = {
+                        t: mr.lookup_values for t, mr in bind_context.items()
+                    }
+                    component_tables_dict = {
+                        t: dict(component_results[t].instances)
+                        for t in component
+                        if t in component_results
+                    }
+                    component_order = topological_sort(dep_graph, component)
+                    self._flush_to_supabase(
+                        component_tables_dict,
+                        component_order,
+                        child_lookup,
+                        stats,
+                        on_event,
+                    )
+                else:
+                    self._flush_sqlalchemy_scope(
+                        component,
+                        bind_context,
+                        dep_graph,
+                        link_to_rels,
+                        backlink_rels,
+                        stats,
+                        on_event,
+                    )
+            elif retain_instances:
+                for table_name, mapping_result in component_results.items():
+                    result_tables[table_name] = dict(mapping_result.instances)
+                if result_raw_results is not None:
+                    for table_name, mapping_result in component_results.items():
+                        if table_name not in result_raw_results:
+                            result_raw_results[table_name] = mapping_result
+                        else:
+                            self._merge_mapping_results(
+                                result_raw_results[table_name], mapping_result
+                            )
+
+            component_errors = self._collect_errors(component_results)
+            for table_name, table_errors in component_errors.items():
+                all_errors.setdefault(table_name, {}).update(table_errors)
+
+            # Evict component-local accumulators
+            component_results.clear()
+
         table_class_map: dict[str, type] = {}
-
-        for table_name, mapping_result in raw_results.items():
-            tables[table_name] = dict(mapping_result.instances)
-            # Collect errors
-            all_errors: dict[tuple[Any, ...], list[str]] = {}
-            for key, msgs in mapping_result.update_errors.items():
-                all_errors.setdefault(key, []).extend(msgs)
-            for key, msgs in mapping_result.finalize_errors.items():
-                all_errors.setdefault(key, []).extend(msgs)
-            if all_errors:
-                errors[table_name] = all_errors
-
-        # Build class map from emissions
         for emission in self._emissions:
             if emission["table_class"]:
                 table_class_map[emission["table"]] = emission["table_class"]
 
-        # Check if we should fail fast on errors
-        if self._error_mode == "fail_fast" and errors:
-            # Raise an exception with details about the first error
-            for table_name, table_errors in errors.items():
+        if self._error_mode == "fail_fast" and all_errors:
+            for table_name, table_errors in all_errors.items():
                 for key, msgs in table_errors.items():
-                    error_msg = f"Validation failed for table '{table_name}' key {key}:\n" + "\n".join(msgs)
+                    error_msg = (
+                        f"Validation failed for table '{table_name}' key {key}:\n"
+                        + "\n".join(msgs)
+                    )
                     raise ValueError(error_msg)
 
-        # If session/client provided, flush in dependency order
-        if self._session is not None:
-            from etielle.utils import topological_sort
-
-            # Build flush order from dependency graph (parents before children)
-            dep_graph = self._build_dependency_graph()
-            all_tables = set(tables.keys())
-            flush_order = topological_sort(dep_graph, all_tables)
-
-            # Check if this is a Supabase client
-            if self._is_supabase_client(self._session):
-                # Error if backlinks are used with Supabase (not supported)
-                if backlink_rels:
-                    raise ValueError(
-                        "backlink() is not supported with Supabase. "
-                        "backlink() relies on ORM-native many-to-many handling "
-                        "which is only available with SQLAlchemy/SQLModel."
-                    )
-                self._flush_to_supabase(
-                    tables, flush_order, child_lookup_values, stats, on_event
-                )
-            else:
-                # SQLAlchemy/SQLModel path
-                # Warn if any relationships use fk (Supabase-only feature)
-                for rel in self._relationships:
-                    if rel.get("fk"):
-                        import warnings
-                        warnings.warn(
-                            f"fk parameter on link_to() is only supported for Supabase. "
-                            f"Ignoring fk={rel['fk']} for {rel['child_table']} -> {rel['parent_table']}.",
-                            UserWarning,
-                            stacklevel=2,
-                        )
-
-                # Build pending bindings index: {child_table: [(rel_spec_idx, parent_table)]}
-                # This tracks which relationships need to be bound when processing each child
-                pending_bindings: dict[str, list[tuple[int, str]]] = {}
-                for idx, spec in enumerate(rel_specs):
-                    pending_bindings.setdefault(spec.child_table, []).append(
-                        (idx, spec.parent_table)
-                    )
-
-                # Process tables in dependency order (parents before children):
-                # 1. Add this table's instances to session
-                # 2. Bind relationships where this table is the CHILD (parents already flushed)
-                # 3. Flush this table
-                for table_name in flush_order:
-                    if table_name not in tables:
-                        continue
-
-                    row_count = len(tables[table_name])
-                    _emit(FlushStarted(table=table_name, count=row_count), on_event)
-
-                    # Add this table's instances to session
-                    for key, instance in tables[table_name].items():
-                        if not isinstance(instance, dict):
-                            self._session.add(instance)
-
-                    # Bind pending parent relationships for this table using secondary indices
-                    # At this point, all parents have been flushed and have IDs
-                    for idx, parent_table in pending_bindings.get(table_name, []):
-                        if parent_table not in raw_results:
-                            continue
-
-                        # Find the relationship spec for this binding
-                        rel = self._relationships[idx]
-                        parent_result = raw_results[parent_table]
-                        child_result = raw_results[table_name]
-
-                        # Infer attr name from parent table name (singular)
-                        attr_name = parent_table.rstrip("s") if parent_table.endswith("s") else parent_table
-
-                        # Get pre-computed child lookup values
-                        lookup_values = child_lookup_values.get(table_name, {})
-
-                        # Bind each child to its parent using secondary indices
-                        for child_key, child_obj in child_result.instances.items():
-                            if isinstance(child_obj, dict):
-                                continue
-                            child_values = lookup_values.get(child_key, {})
-
-                            for child_field, parent_field in rel["by"].items():
-                                lookup_value = child_values.get(child_field)
-                                if lookup_value is None:
-                                    continue
-
-                                parent_index = parent_result.indices.get(parent_field, {})
-                                parent_obj = parent_index.get(lookup_value)
-
-                                if parent_obj is not None:
-                                    setattr(child_obj, attr_name, parent_obj)
-
-                    # Flush this table - relationships are bound, FKs will be set
-                    try:
-                        self._session.flush()
-                        _emit(
-                            FlushCompleted(
-                                table=table_name,
-                                inserted=row_count,
-                                failed=0,
-                                batch_num=1,
-                                batch_total=1,
-                                upsert=False,
-                            ),
-                            on_event,
-                        )
-                        # Update stats
-                        if table_name in stats:
-                            stats[table_name] = TableStats(
-                                mapped=stats[table_name].mapped,
-                                errors=stats[table_name].errors,
-                                inserted=row_count,
-                                failed=0,
-                            )
-                    except Exception as e:
-                        _emit(
-                            FlushFailed(
-                                table=table_name,
-                                error=str(e),
-                                affected_count=row_count,
-                            ),
-                            on_event,
-                        )
-                        # Update stats
-                        if table_name in stats:
-                            stats[table_name] = TableStats(
-                                mapped=stats[table_name].mapped,
-                                errors=stats[table_name].errors,
-                                inserted=0,
-                                failed=row_count,
-                            )
-                        raise
-
-                # After all tables are flushed, bind backlinks
-                # This sets list attributes on parent objects
-                if backlink_rels:
-                    from etielle.relationships import bind_backlinks
-                    bind_backlinks(
-                        raw_results, backlink_rels, backlink_lookup_values, fail_on_missing=False
-                    )
-                    # Final flush to persist backlink relationships
-                    self._session.flush()
-
         return PipelineResult(
-            tables=tables,
-            errors=errors,
+            tables=result_tables,
+            errors=all_errors,
             _table_class_map=table_class_map,
-            _raw_results=raw_results,
+            _raw_results=result_raw_results,
             _stats=stats,
         )
 

--- a/etielle/relationships.py
+++ b/etielle/relationships.py
@@ -524,6 +524,9 @@ def bind_relationships_via_index(
                         all_errors.append(f"Parent not found for {parent_field}={lookup_value}")
                     continue
 
+                if isinstance(child_obj, dict):
+                    continue
+
                 # Set relationship
                 setattr(child_obj, attr_name, parent_obj)
 

--- a/etielle/utils.py
+++ b/etielle/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for etielle."""
 
-from typing import Dict, Set, List
+from typing import Dict, List, Set
 
 
 def topological_sort(
@@ -52,3 +52,91 @@ def topological_sort(
         raise ValueError(f"Circular dependency detected involving: {remaining}")
 
     return result
+
+
+def weakly_connected_components(
+    graph: Dict[str, Set[str]],
+    nodes: Set[str],
+) -> List[Set[str]]:
+    """Partition nodes into weakly connected components.
+
+    Args:
+        graph: Dict mapping child -> set of parent nodes (directed edges).
+        nodes: All nodes to include.
+
+    Returns:
+        List of component sets in deterministic order (sorted by first member).
+    """
+    adj: Dict[str, Set[str]] = {node: set() for node in nodes}
+
+    for child, parents in graph.items():
+        if child not in nodes:
+            continue
+        for parent in parents:
+            if parent in nodes:
+                adj[child].add(parent)
+                adj[parent].add(child)
+
+    visited: Set[str] = set()
+    components: List[Set[str]] = []
+
+    for start in sorted(nodes):
+        if start in visited:
+            continue
+        component: Set[str] = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            component.add(node)
+            for neighbor in sorted(adj.get(node, set())):
+                if neighbor not in visited:
+                    stack.append(neighbor)
+        components.append(component)
+
+    return components
+
+
+def partition_components(
+    graph: Dict[str, Set[str]],
+    all_tables: Set[str],
+    eager_tables: Set[str],
+) -> List[Set[str]]:
+    """Partition non-eager tables into weakly connected components.
+
+    Edges involving eager tables are excluded from partitioning so shared
+    dimension tables do not collapse unrelated subgraphs into one component.
+    """
+    partition_nodes = all_tables - eager_tables
+    if not partition_nodes:
+        return []
+
+    partition_graph: Dict[str, Set[str]] = {}
+    related_tables: Set[str] = set()
+    for child, parents in graph.items():
+        if child not in partition_nodes:
+            continue
+        filtered = {
+            parent
+            for parent in parents
+            if parent in partition_nodes and parent not in eager_tables
+        }
+        if filtered:
+            partition_graph[child] = filtered
+            related_tables.add(child)
+            related_tables.update(filtered)
+
+    orphan_tables = partition_nodes - related_tables
+    components: List[Set[str]] = []
+
+    if related_tables:
+        components.extend(
+            weakly_connected_components(partition_graph, related_tables)
+        )
+    if orphan_tables:
+        components.append(orphan_tables)
+
+    return components
+

--- a/tests/test_fluent_sqlalchemy.py
+++ b/tests/test_fluent_sqlalchemy.py
@@ -804,14 +804,11 @@ class TestDatabaseLoadingEdgeCases:
         assert len(users) == 2, "ORM User instances should be persisted"
         assert {u.name for u in users} == {"Alice", "Bob"}
 
-        # Verify dict instances are in result but not in database
-        assert "metadata" in result.tables
-        metadata_dict = result.tables["metadata"]
-        assert len(metadata_dict) == 2, "Dict instances should be in result.tables"
-
-        # Dict instances should not be in session (no table to query)
-        # We can verify this by checking that session.new is empty after the load
-        # (since we already committed, and dicts shouldn't have been added)
+        # load().run() does not retain flushed instances in result.tables
+        assert "users" not in result.tables
+        assert "metadata" not in result.tables
+        assert result.stats["users"].inserted == 2
+        assert result.stats["metadata"].mapped == 2
 
     def test_batch_with_errors_allows_selective_rollback(self, session):
         """Processing multiple batches allows checking errors per batch for selective rollback.

--- a/tests/test_issue_9a.py
+++ b/tests/test_issue_9a.py
@@ -1,0 +1,382 @@
+"""Tests for issue #9A: single-pass execution and component-scoped flush/evict."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from etielle import Field, TempField, etl, get
+from etielle.utils import partition_components, weakly_connected_components
+
+
+Base = declarative_base()
+
+
+class Tag(Base):
+    __tablename__ = "tags"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    tag_id = Column(Integer, ForeignKey("tags.id"))
+
+
+class UserA(Base):
+    __tablename__ = "users_a"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class PostA(Base):
+    __tablename__ = "posts_a"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    user_id = Column(Integer, ForeignKey("users_a.id"))
+
+
+class UserB(Base):
+    __tablename__ = "users_b"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class PostB(Base):
+    __tablename__ = "posts_b"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    user_id = Column(Integer, ForeignKey("users_b.id"))
+
+
+@dataclass
+class Parent:
+    id: str
+
+
+@dataclass
+class Child:
+    id: str
+    parent: Parent | None = None
+
+
+class TestWeaklyConnectedComponents:
+    def test_two_isolated_components(self):
+        graph = {
+            "posts_a": {"users_a"},
+            "posts_b": {"users_b"},
+        }
+        nodes = {"users_a", "posts_a", "users_b", "posts_b"}
+        components = weakly_connected_components(graph, nodes)
+        assert len(components) == 2
+        assert {"users_a", "posts_a"} in components
+        assert {"users_b", "posts_b"} in components
+
+    def test_orphan_tables_grouped(self):
+        graph = {"posts": {"users"}}
+        all_tables = {"users", "posts", "metrics", "logs"}
+        components = partition_components(graph, all_tables, set())
+        assert len(components) == 2
+        assert {"users", "posts"} in components
+        assert {"metrics", "logs"} in components
+
+    def test_eager_edges_excluded(self):
+        graph = {
+            "items_0": {"tags"},
+            "items_1": {"tags"},
+        }
+        all_tables = {"tags", "items_0", "items_1"}
+        components = partition_components(graph, all_tables, {"tags"})
+        # Orphan item tables batch together for mapping efficiency
+        assert len(components) == 1
+        assert components[0] == {"items_0", "items_1"}
+
+
+class TestSinglePassLookupCapture:
+    def test_lookup_values_captured_during_mapping(self):
+        data = {
+            "parents": [{"id": "p1"}],
+            "children": [{"id": "c1", "parent_id": "p1"}],
+        }
+
+        result = (
+            etl(data)
+            .goto("parents")
+            .each()
+            .map_to(
+                table=Parent,
+                fields=[
+                    Field("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("children")
+            .each()
+            .map_to(
+                table=Child,
+                fields=[
+                    Field("id", get("id")),
+                    TempField("parent_id", get("parent_id")),
+                ],
+            )
+            .link_to(Parent, by={"parent_id": "id"})
+            .run()
+        )
+
+        child = next(iter(result.tables[Child].values()))
+        assert child.parent is not None
+        assert child.parent.id == "p1"
+
+        with patch(
+            "etielle.relationships.compute_child_lookup_values",
+            side_effect=AssertionError("should not re-traverse"),
+        ):
+            # Re-bind using captured lookup values only
+            from etielle.relationships import bind_relationships_via_index
+
+            raw = result._raw_results
+            rels = [
+                {
+                    "child_table": "child",
+                    "parent_table": "parent",
+                    "by": {"parent_id": "id"},
+                }
+            ]
+            lookup = {t: mr.lookup_values for t, mr in raw.items()}
+            bind_relationships_via_index(raw, rels, lookup, fail_on_missing=False)
+
+    def test_no_compute_child_lookup_in_run(self):
+        data = {
+            "parents": [{"id": "p1"}],
+            "children": [{"id": "c1", "parent_id": "p1"}],
+        }
+
+        with patch(
+            "etielle.relationships.compute_child_lookup_values",
+            side_effect=AssertionError("compute_child_lookup_values called"),
+        ), patch(
+            "etielle.relationships.compute_backlink_lookup_values",
+            side_effect=AssertionError("compute_backlink_lookup_values called"),
+        ):
+            (
+                etl(data)
+                .goto("parents")
+                .each()
+                .map_to(
+                    table=Parent,
+                    fields=[Field("id", get("id"))],
+                )
+                .goto_root()
+                .goto("children")
+                .each()
+                .map_to(
+                    table=Child,
+                    fields=[
+                        Field("id", get("id")),
+                        TempField("parent_id", get("parent_id")),
+                    ],
+                )
+                .link_to(Parent, by={"parent_id": "id"})
+                .run()
+            )
+
+
+class TestComponentEviction:
+    def test_component_instances_not_retained_after_load(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        data = {
+            "users_a": [{"id": 1, "name": "A"}],
+            "posts_a": [{"id": 1, "title": "pa", "user_id": 1}],
+            "users_b": [{"id": 2, "name": "B"}],
+            "posts_b": [{"id": 2, "title": "pb", "user_id": 2}],
+        }
+
+        result = (
+            etl(data)
+            .goto("users_a")
+            .each()
+            .map_to(
+                table=UserA,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("posts_a")
+            .each()
+            .map_to(
+                table=PostA,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(UserA, by={"user_id": "id"})
+            .goto_root()
+            .goto("users_b")
+            .each()
+            .map_to(
+                table=UserB,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("posts_b")
+            .each()
+            .map_to(
+                table=PostB,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(UserB, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+
+        session.commit()
+        assert "users_a" not in result.tables
+        assert session.query(UserA).count() == 1
+        assert session.query(UserB).count() == 1
+        session.close()
+
+
+class TestLoadEager:
+    def test_eager_parent_shared_across_components(self):
+        data = {
+            "tags": [{"id": 1, "name": "t1"}, {"id": 2, "name": "t2"}],
+            "items_0": [{"id": 1, "name": "i0", "tag_id": 1}],
+            "items_1": [{"id": 2, "name": "i1", "tag_id": 2}],
+        }
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            etl(data)
+            .goto("tags")
+            .each()
+            .map_to(
+                table=Tag,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load_eager(Tag)
+            .goto_root()
+            .goto("items_0")
+            .each()
+            .map_to(
+                table="items_0",
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(Tag, by={"tag_id": "id"})
+            .goto_root()
+            .goto("items_1")
+            .each()
+            .map_to(
+                table="items_1",
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(Tag, by={"tag_id": "id"})
+            .load(session)
+            .run()
+        )
+
+        session.commit()
+        assert session.query(Tag).count() == 2
+        session.close()
+
+    def test_load_eager_requires_map_to(self):
+        with pytest.raises(ValueError, match="requires a preceding map_to"):
+            etl({}).load_eager("missing").run()
+
+    def test_load_eager_rejects_non_eager_parent_dependency(self):
+        data = {"parents": [], "children": []}
+
+        builder = (
+            etl(data)
+            .goto("parents")
+            .each()
+            .map_to(table="parents", fields=[])
+            .goto_root()
+            .goto("children")
+            .each()
+            .map_to(table="children", fields=[TempField("pid", get("pid"))])
+            .link_to("parents", by={"pid": "id"})
+            .load_eager("children")
+        )
+
+        with pytest.raises(ValueError, match="cannot depend on non-eager"):
+            builder.run()
+
+
+class TestLoadModeResultContract:
+    def test_load_mode_returns_stats_not_instances(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        result = (
+            etl({"users": [{"id": 1, "name": "Alice"}]})
+            .goto("users")
+            .each()
+            .map_to(
+                table=UserA,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+
+        assert "users_a" not in result.tables
+        assert result.stats["users_a"].inserted == 1
+        session.close()
+
+    def test_non_load_mode_still_returns_instances(self):
+        result = (
+            etl({"users": [{"id": 1, "name": "Alice"}]})
+            .goto("users")
+            .each()
+            .map_to(
+                table=UserA,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .run()
+        )
+        assert "users_a" in result.tables
+        assert len(result.tables["users_a"]) == 1

--- a/tests/test_supabase_adapter.py
+++ b/tests/test_supabase_adapter.py
@@ -122,9 +122,11 @@ class TestSupabaseFlush:
         mock_supabase_client.table.assert_called_with("users")
         mock_supabase_client.table.return_value.insert.assert_called_once()
 
-        # Check that we got results back
-        assert "users" in result.tables
-        assert len(result.tables["users"]) == 2
+        # Check that we got stats back (instances are not retained after load)
+        assert "users" in result.stats
+        assert result.stats["users"].mapped == 2
+        assert result.stats["users"].inserted == 2
+        assert "users" not in result.tables
 
     def test_multi_table_insert_with_dependency_order(self, mock_supabase_client):
         """Should insert parent tables before child tables."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,3 +57,21 @@ class TestTopologicalSort:
         # a before b, c can be anywhere (it's independent)
         assert result.index("a") < result.index("b")
         assert "c" in result
+
+
+class TestWeaklyConnectedComponents:
+    def test_two_components(self):
+        from etielle.utils import weakly_connected_components
+
+        graph = {"posts": {"users"}, "comments": {"articles"}}
+        nodes = {"users", "posts", "articles", "comments"}
+        components = weakly_connected_components(graph, nodes)
+        assert len(components) == 2
+
+    def test_partition_with_eager(self):
+        from etielle.utils import partition_components
+
+        graph = {"items_a": {"tags"}, "items_b": {"tags"}}
+        all_tables = {"tags", "items_a", "items_b"}
+        components = partition_components(graph, all_tables, {"tags"})
+        assert components == [{"items_a", "items_b"}]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements issue #9 sub-issue A (#74): single-pass execution, component-scoped flush/evict, and `load_eager()`.

## Summary

- **Single-pass binding**: relationship lookup values are captured during `run_mapping()` via `MappingResult.lookup_values`. The fluent path no longer calls `compute_child_lookup_values()` / `compute_backlink_lookup_values()`.
- **Component execution**: tables are partitioned by weakly connected relationship components (with orphan tables batched together). Each component is mapped → bound → flushed → evicted.
- **`load_eager(table)`**: shared dimension tables load once and stay resident for cross-component binding.
- **Benchmark harness**: `benchmarks/bench_issue_9a.py` measures wall time, heap peak, and RSS for representative shapes.

## Breaking change

`load().run()` no longer retains flushed instances in `PipelineResult.tables`. It returns **stats and errors**; query the session/DB for persisted rows. Non-load `.run()` behavior is unchanged.

This is intended for a **major version** release (`feat!` commit).

## Benchmark snapshot (scale=200, load mode, post-change)

| Scenario | RSS peak (KB) | Wall time (s) | Rows mapped |
| --- | ---: | ---: | ---: |
| no_relationships | 50240 | 0.030 | 2000 |
| many_components (100 pairs) | 50240 | 0.033 | 200 |
| single_component | 52616 | 0.083 | 600 |
| eager_dimension_without_eager | 52616 | 0.026 | 105 |
| eager_dimension_with_eager | 52616 | 0.016 | 105 |

Run before/after comparison:

```bash
uv run python benchmarks/bench_issue_9a.py run --scale 500 --load --output artifacts/bench-before.json  # on main/v3
uv run python benchmarks/bench_issue_9a.py run --scale 500 --load --output artifacts/bench-after.json   # on this branch
uv run python benchmarks/bench_issue_9a.py compare artifacts/bench-before.json artifacts/bench-after.json --markdown artifacts/comparison.md
```

## Tests

- 311 passed (4 skipped)
- New acceptance tests in `tests/test_issue_9a.py`

## Docs

- Updated `docs/database-loading.qmd` and `docs/introduction-to-etl.qmd` for component flushing, `load_eager()`, and the new load-mode result contract.

Closes #74. Part of #9 roadmap item A.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4235c584-e2c8-4640-984e-ff27c5624ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4235c584-e2c8-4640-984e-ff27c5624ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

