### PR TITLE
feat: streaming/chunked execution (key-complete contract, issue #75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ uv.lock
 
 # Local Supabase
 supabase/
+
+# Benchmark run artifacts
+artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- version list -->
 
+## v4.1.0 (Unreleased)
+
+### Features
+
+- Streaming/chunked execution via `stream()` with `ChunkSource` and `FlushStrategy` seams
+- `KeyCompleteFlushStrategy` as the default flush strategy for streaming
+- Relationship-completeness validation for incomplete chunks
+- Additive per-table stats across chunk boundaries
+
 ## v4.0.0 (2026-06-25)
 
 ### Features

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -43,3 +43,33 @@ uv run python benchmarks/bench_issue_9a.py compare \
 
 Use `--load` to measure load-mode behavior where flushed instances are not retained
 in `PipelineResult.tables`.
+
+# Issue 75 benchmark (streaming bounded memory)
+
+`bench_issue_75.py` loads the same dataset three ways and reports Python heap peak
+(`tracemalloc`) and process RSS peak during the run:
+
+- **resident** — `etl(all_data).load(session).run()` (the only pre-#75 option)
+- **stream_no_evict** — `stream(chunks)` with `KeyCompleteFlushStrategy(evict_flushed=False)`
+- **stream_evict** — `stream(chunks)` with eviction on (default)
+
+```bash
+uv run python benchmarks/bench_issue_75.py --scale 8000
+```
+
+## Sample result (scale=8000, 2 KiB/row payload, in-memory SQLite)
+
+| mode            | heap peak | rss peak | wall |
+|-----------------|-----------|----------|------|
+| resident        | 45.5 MiB  | 227.9 MiB| 2.4s |
+| stream_no_evict | 0.23 MiB  | 227.9 MiB| 13.1s|
+| stream_evict    | 0.23 MiB  | 227.9 MiB| 13.5s|
+
+Streaming holds a flat ~0.23 MiB heap peak independent of dataset size (resident grows
+linearly: 17.9 MiB at scale 3000, 45.5 MiB at scale 8000), confirming the bounded-memory
+property. `stream_evict` and `stream_no_evict` are equivalent on heap because SQLAlchemy's
+identity map references persistent instances weakly, so the GC reclaims them once etielle
+releases its per-chunk accumulators; explicit eviction makes the bound deterministic rather
+than reducing peak heap further. RSS is a process high-water mark and does not fall, so heap
+peak is the meaningful signal here. The wall-time cost is the per-chunk flush overhead of
+streaming, traded for the memory bound.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,12 +46,11 @@ in `PipelineResult.tables`.
 
 # Issue 75 benchmark (streaming bounded memory)
 
-`bench_issue_75.py` loads the same dataset three ways and reports Python heap peak
+`bench_issue_75.py` loads the same dataset two ways and reports Python heap peak
 (`tracemalloc`) and process RSS peak during the run:
 
 - **resident** — `etl(all_data).load(session).run()` (the only pre-#75 option)
-- **stream_no_evict** — `stream(chunks)` with `KeyCompleteFlushStrategy(evict_flushed=False)`
-- **stream_evict** — `stream(chunks)` with eviction on (default)
+- **streaming** — `stream(chunks).load(session).run()`
 
 ```bash
 uv run python benchmarks/bench_issue_75.py --scale 8000
@@ -59,17 +58,15 @@ uv run python benchmarks/bench_issue_75.py --scale 8000
 
 ## Sample result (scale=8000, 2 KiB/row payload, in-memory SQLite)
 
-| mode            | heap peak | rss peak | wall |
-|-----------------|-----------|----------|------|
-| resident        | 45.5 MiB  | 227.9 MiB| 2.4s |
-| stream_no_evict | 0.23 MiB  | 227.9 MiB| 13.1s|
-| stream_evict    | 0.23 MiB  | 227.9 MiB| 13.5s|
+| mode      | heap peak | rss peak  | wall  |
+|-----------|-----------|-----------|-------|
+| resident  | 45.5 MiB  | 227.9 MiB | 2.4s  |
+| streaming | 0.23 MiB  | 227.9 MiB | 13.1s |
 
 Streaming holds a flat ~0.23 MiB heap peak independent of dataset size (resident grows
 linearly: 17.9 MiB at scale 3000, 45.5 MiB at scale 8000), confirming the bounded-memory
-property. `stream_evict` and `stream_no_evict` are equivalent on heap because SQLAlchemy's
-identity map references persistent instances weakly, so the GC reclaims them once etielle
-releases its per-chunk accumulators; explicit eviction makes the bound deterministic rather
-than reducing peak heap further. RSS is a process high-water mark and does not fall, so heap
-peak is the meaningful signal here. The wall-time cost is the per-chunk flush overhead of
-streaming, traded for the memory bound.
+property. On the SQLAlchemy side this needs no explicit eviction: the identity map references
+persistent instances weakly, so the GC reclaims them once etielle releases its per-chunk
+accumulators. RSS is a process high-water mark and does not fall, so heap peak is the
+meaningful signal here. The wall-time cost is the per-chunk flush overhead of streaming,
+traded for the memory bound.

--- a/benchmarks/bench_issue_75.py
+++ b/benchmarks/bench_issue_75.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Benchmark harness for issue #75: streaming + chunked execution.
+
+Demonstrates the bounded-memory property of streaming versus resident loading,
+and the effect of session eviction. All modes load the same logical dataset
+into a SQLAlchemy session and measure Python heap peak (tracemalloc) and process
+RSS peak during the run.
+
+Modes:
+  - resident:        etl(all_data).load(session).run()  (the only pre-#75 option)
+  - stream_evict:    stream(chunks).load(session).run() (eviction on, default)
+  - stream_no_evict: stream(chunks, KeyCompleteFlushStrategy(evict_flushed=False))
+
+Usage:
+    uv run python benchmarks/bench_issue_75.py --scale 2000
+    uv run python benchmarks/bench_issue_75.py --scale 2000 --output artifacts/bench75.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import resource
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, KeyCompleteFlushStrategy, etl, get, stream
+from etielle.chunking import CallableChunkSource, Chunk
+
+Base = declarative_base()
+
+# A payload large enough that retaining every instance is visibly costly.
+_PAYLOAD = "x" * 2048
+
+
+class B75User(Base):
+    __tablename__ = "b75_users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    payload = Column(String)
+
+
+class B75Post(Base):
+    __tablename__ = "b75_posts"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    payload = Column(String)
+    user_id = Column(Integer, ForeignKey("b75_users.id"))
+    b75_user = relationship("B75User")
+
+
+@dataclass
+class BenchResult:
+    name: str
+    scale: int
+    wall_seconds: float
+    heap_peak_bytes: int
+    rss_peak_kb: int
+    rows_inserted: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "scale": self.scale,
+            "wall_seconds": round(self.wall_seconds, 4),
+            "heap_peak_bytes": self.heap_peak_bytes,
+            "heap_peak_mib": round(self.heap_peak_bytes / 1024 / 1024, 2),
+            "rss_peak_kb": self.rss_peak_kb,
+            "rss_peak_mib": round(self.rss_peak_kb / 1024, 2),
+            "rows_inserted": self.rows_inserted,
+        }
+
+
+def _rss_kb() -> int:
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss // 1024 if sys.platform == "darwin" else rss
+
+
+def _fresh_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _record(i: int) -> dict[str, Any]:
+    return {
+        "users": [{"id": i, "name": f"user_{i}", "payload": _PAYLOAD}],
+        "posts": [{"id": i, "title": f"post_{i}", "payload": _PAYLOAD, "user_id": i}],
+    }
+
+
+def _resident_data(scale: int) -> dict[str, Any]:
+    return {
+        "users": [
+            {"id": i, "name": f"user_{i}", "payload": _PAYLOAD} for i in range(scale)
+        ],
+        "posts": [
+            {"id": i, "title": f"post_{i}", "payload": _PAYLOAD, "user_id": i}
+            for i in range(scale)
+        ],
+    }
+
+
+def _user_fields() -> list[Any]:
+    return [
+        Field("name", get("name")),
+        Field("payload", get("payload")),
+        TempField("id", get("id")),
+    ]
+
+
+def _post_fields() -> list[Any]:
+    return [
+        Field("title", get("title")),
+        Field("payload", get("payload")),
+        TempField("id", get("id")),
+        TempField("user_id", get("user_id")),
+    ]
+
+
+def _run_resident(scale: int) -> Callable[[], Any]:
+    def go() -> Any:
+        session = _fresh_session()
+        result = (
+            etl(_resident_data(scale))
+            .goto("users").each().map_to(table=B75User, fields=_user_fields())
+            .goto_root()
+            .goto("posts").each().map_to(table=B75Post, fields=_post_fields())
+            .link_to(B75User, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+        session.close()
+        return result
+
+    return go
+
+
+def _run_streaming(scale: int, *, evict: bool) -> Callable[[], Any]:
+    def go() -> Any:
+        session = _fresh_session()
+        source = CallableChunkSource(
+            lambda: (
+                Chunk(roots=(_record(i),), sequential=True) for i in range(scale)
+            )
+        )
+        result = (
+            stream(source, flush_strategy=KeyCompleteFlushStrategy(evict_flushed=evict))
+            .goto("users").each().map_to(table=B75User, fields=_user_fields())
+            .goto_root()
+            .goto("posts").each().map_to(table=B75Post, fields=_post_fields())
+            .link_to(B75User, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+        session.close()
+        return result
+
+    return go
+
+
+def _bench(name: str, scale: int, fn: Callable[[], Any]) -> BenchResult:
+    gc.collect()
+    tracemalloc.start()
+    rss_before = _rss_kb()
+    t0 = time.perf_counter()
+    result = fn()
+    wall = time.perf_counter() - t0
+    _, heap_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_peak = max(_rss_kb(), rss_before)
+    rows = sum(s.inserted for s in result.stats.values())
+    gc.collect()
+    return BenchResult(
+        name=name,
+        scale=scale,
+        wall_seconds=wall,
+        heap_peak_bytes=heap_peak,
+        rss_peak_kb=rss_peak,
+        rows_inserted=rows,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark issue #75 streaming memory")
+    parser.add_argument("--scale", type=int, default=2000, help="number of records")
+    parser.add_argument("--output", type=str, default=None, help="write JSON report")
+    args = parser.parse_args()
+
+    scale = args.scale
+    results = [
+        _bench("resident", scale, _run_resident(scale)),
+        _bench("stream_no_evict", scale, _run_streaming(scale, evict=False)),
+        _bench("stream_evict", scale, _run_streaming(scale, evict=True)),
+    ]
+
+    print(f"\nissue #75 streaming memory benchmark (scale={scale}, payload=2KiB/row)\n")
+    header = f"{'mode':<18}{'heap_peak_MiB':>16}{'rss_peak_MiB':>16}{'wall_s':>10}{'rows':>8}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        d = r.to_dict()
+        print(
+            f"{d['name']:<18}{d['heap_peak_mib']:>16}{d['rss_peak_mib']:>16}"
+            f"{d['wall_seconds']:>10}{d['rows_inserted']:>8}"
+        )
+
+    base = next(r for r in results if r.name == "resident")
+    evicted = next(r for r in results if r.name == "stream_evict")
+    if base.heap_peak_bytes:
+        ratio = evicted.heap_peak_bytes / base.heap_peak_bytes
+        print(
+            f"\nstream_evict heap peak is {ratio:.2%} of resident "
+            f"({base.heap_peak_bytes / 1024 / 1024:.1f} MiB -> "
+            f"{evicted.heap_peak_bytes / 1024 / 1024:.1f} MiB)"
+        )
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        report = {
+            "python_version": sys.version,
+            "scale": scale,
+            "results": [r.to_dict() for r in results],
+        }
+        out.write_text(json.dumps(report, indent=2))
+        print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_issue_75.py
+++ b/benchmarks/bench_issue_75.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 """Benchmark harness for issue #75: streaming + chunked execution.
 
-Demonstrates the bounded-memory property of streaming versus resident loading,
-and the effect of session eviction. All modes load the same logical dataset
-into a SQLAlchemy session and measure Python heap peak (tracemalloc) and process
-RSS peak during the run.
+Demonstrates the bounded-memory property of streaming versus resident loading.
+Both modes load the same logical dataset into a SQLAlchemy session and measure
+Python heap peak (tracemalloc) and process RSS peak during the run.
 
 Modes:
-  - resident:        etl(all_data).load(session).run()  (the only pre-#75 option)
-  - stream_evict:    stream(chunks).load(session).run() (eviction on, default)
-  - stream_no_evict: stream(chunks, KeyCompleteFlushStrategy(evict_flushed=False))
+  - resident:  etl(all_data).load(session).run()  (the only pre-#75 option)
+  - streaming: stream(chunks).load(session).run()
 
 Usage:
     uv run python benchmarks/bench_issue_75.py --scale 2000
@@ -32,7 +30,7 @@ from typing import Any, Callable
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
-from etielle import Field, TempField, KeyCompleteFlushStrategy, etl, get, stream
+from etielle import Field, TempField, etl, get, stream
 from etielle.chunking import CallableChunkSource, Chunk
 
 Base = declarative_base()
@@ -145,7 +143,7 @@ def _run_resident(scale: int) -> Callable[[], Any]:
     return go
 
 
-def _run_streaming(scale: int, *, evict: bool) -> Callable[[], Any]:
+def _run_streaming(scale: int) -> Callable[[], Any]:
     def go() -> Any:
         session = _fresh_session()
         source = CallableChunkSource(
@@ -154,7 +152,7 @@ def _run_streaming(scale: int, *, evict: bool) -> Callable[[], Any]:
             )
         )
         result = (
-            stream(source, flush_strategy=KeyCompleteFlushStrategy(evict_flushed=evict))
+            stream(source)
             .goto("users").each().map_to(table=B75User, fields=_user_fields())
             .goto_root()
             .goto("posts").each().map_to(table=B75Post, fields=_post_fields())
@@ -200,8 +198,7 @@ def main() -> None:
     scale = args.scale
     results = [
         _bench("resident", scale, _run_resident(scale)),
-        _bench("stream_no_evict", scale, _run_streaming(scale, evict=False)),
-        _bench("stream_evict", scale, _run_streaming(scale, evict=True)),
+        _bench("streaming", scale, _run_streaming(scale)),
     ]
 
     print(f"\nissue #75 streaming memory benchmark (scale={scale}, payload=2KiB/row)\n")
@@ -216,13 +213,13 @@ def main() -> None:
         )
 
     base = next(r for r in results if r.name == "resident")
-    evicted = next(r for r in results if r.name == "stream_evict")
+    streaming = next(r for r in results if r.name == "streaming")
     if base.heap_peak_bytes:
-        ratio = evicted.heap_peak_bytes / base.heap_peak_bytes
+        ratio = streaming.heap_peak_bytes / base.heap_peak_bytes
         print(
-            f"\nstream_evict heap peak is {ratio:.2%} of resident "
+            f"\nstreaming heap peak is {ratio:.2%} of resident "
             f"({base.heap_peak_bytes / 1024 / 1024:.1f} MiB -> "
-            f"{evicted.heap_peak_bytes / 1024 / 1024:.1f} MiB)"
+            f"{streaming.heap_peak_bytes / 1024 / 1024:.1f} MiB)"
         )
 
     if args.output:

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -257,6 +257,43 @@ result = (
 
 `load_eager()` requires an explicit preceding `map_to()` for the same table.
 
+## Streaming and Chunked Execution
+
+For large or single-consumption inputs (paginated APIs, `ijson` streams), use `stream()` instead of `etl()`. Streaming mode processes **key-complete, relationship-complete** chunks: each chunk is mapped, validated, bound, flushed, and evicted before the next chunk begins.
+
+```python
+from etielle import stream, Field, TempField, get
+
+# One JSON root per chunk (default)
+result = (
+    stream(record_iter)
+    .goto("users").each()
+    .map_to(table=User, fields=[...])
+    .load(session)
+    .run()
+)
+session.commit()
+```
+
+**Requirements and restrictions:**
+
+- `load()` is required before `run()` in streaming mode.
+- Chunks must include all relationship endpoints (or use `load_eager()` for shared parents).
+- Cross-chunk scattered merge (e.g. merging `users` and `profiles` from different chunks) is not supported.
+- Traversal-based `build_index()` and composite `by` mappings on `link_to()` are rejected.
+
+Pass resident eager data via `eager_roots=` when dimension tables are not repeated in every chunk:
+
+```python
+stream(chunks, eager_roots=tags_snapshot)
+    .goto("tags").each()
+    .map_to(table=Tag, fields=[...])
+    .load_eager(Tag)
+    ...
+```
+
+For arbitrarily grouped input, see the chunking helpers in issue #76 (`ChunkSource` group-by and pre-segmented passthrough).
+
 ## Upsert Behavior
 
 etielle uses "upsert" semantics---if a row with the same key already exists, it's updated:

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -294,6 +294,14 @@ stream(chunks, eager_roots=tags_snapshot)
 
 For arbitrarily grouped input, see the chunking helpers in issue #76 (`ChunkSource` group-by and pre-segmented passthrough).
 
+### Bounding memory on the SQLAlchemy path
+
+Streaming evicts etielle's own per-chunk accumulators, but a SQLAlchemy `Session` keeps every flushed instance in its identity map until the transaction ends or the instances are expunged. Over many chunks this identity map—not etielle—becomes the dominant memory cost. To keep memory bounded across a long stream, the caller should periodically clear the session, for example by committing (or flushing and calling `Session.expunge_all()`) at a cadence appropriate for the workload. etielle does not commit or expunge on your behalf, so transaction control stays with the caller.
+
+### Extending flush behavior
+
+The chunk loop is strategy-agnostic: it calls `FlushStrategy.flush(ctx)` at each component boundary. A custom strategy receives a `FlushContext` exposing the scoped tables, mapped results, dependency graph, relationships, stats sink, telemetry callback, and the `session`/`is_supabase` target. Custom strategies (e.g. upsert or buffered variants from issue #77) implement persistence using those public fields plus `etielle.utils.topological_sort`; the built-in `KeyCompleteFlushStrategy` delegates to etielle's standard insert/bind logic.
+
 ## Upsert Behavior
 
 etielle uses "upsert" semantics---if a row with the same key already exists, it's updated:

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -294,24 +294,11 @@ stream(chunks, eager_roots=tags_snapshot)
 
 For arbitrarily grouped input, see the chunking helpers in issue #76 (`ChunkSource` group-by and pre-segmented passthrough).
 
-### Bounding memory on the SQLAlchemy path
+### Why streaming bounds memory
 
-A SQLAlchemy `Session` tracks flushed instances in its identity map until the transaction ends or the instances are expunged. In streaming mode etielle expunges each component's flushed instances from the session after the chunk is flushed (the default `KeyCompleteFlushStrategy(evict_flushed=True)`), bounding the identity map to one component plus any resident `load_eager()` tables, which are deliberately never evicted.
+Streaming keeps peak memory flat regardless of dataset size: etielle maps a chunk, flushes it, and releases that chunk's accumulators before mapping the next, so it never holds more than one chunk (plus any resident `load_eager()` tables) at a time. The benchmark in `benchmarks/bench_issue_75.py` shows the Python heap peak staying flat under streaming while resident loading grows linearly with the dataset.
 
-In practice the dominant memory win comes from streaming itself: etielle releases each chunk's accumulators before mapping the next, so peak heap stays flat regardless of dataset size (see `benchmarks/bench_issue_75.py`). Because SQLAlchemy's identity map references *persistent* instances weakly, CPython's garbage collector already reclaims them once etielle drops its references, so explicit eviction adds little measurable heap savings under the default session configuration. Its value is making the bound deterministic rather than GC-timing-dependent, and covering sessions configured to hold instances strongly or callers that retain references.
-
-Eviction is purely a memory concern and does **not** touch your transaction: the `INSERT`s remain in the open transaction, and commit/rollback stays the caller's responsibility. After you commit, the rows are queryable normally.
-
-Disable eviction with `flush_strategy=KeyCompleteFlushStrategy(evict_flushed=False)` if you need to keep working with the flushed ORM objects after the run, or if your models declare an aggressive `cascade` (e.g. `"all"`) on the child→parent direction that would detach resident eager parents:
-
-```python
-from etielle import stream, KeyCompleteFlushStrategy
-
-stream(chunks, flush_strategy=KeyCompleteFlushStrategy(evict_flushed=False))
-    ...
-```
-
-Resident `etl(...)` runs do not evict and keep today's behavior unchanged.
+On the SQLAlchemy side this needs no special handling: the session's identity map references *persistent* (flushed, clean) instances weakly, so once etielle drops its per-chunk references, CPython's garbage collector reclaims them. Transaction control still belongs to the caller—the `INSERT`s accumulate in the open transaction until you commit or roll back. For a very long stream, commit at a cadence that suits your durability needs; a single end-of-stream commit keeps everything in one transaction.
 
 ### Extending flush behavior
 

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -296,7 +296,22 @@ For arbitrarily grouped input, see the chunking helpers in issue #76 (`ChunkSour
 
 ### Bounding memory on the SQLAlchemy path
 
-Streaming evicts etielle's own per-chunk accumulators, but a SQLAlchemy `Session` keeps every flushed instance in its identity map until the transaction ends or the instances are expunged. Over many chunks this identity map—not etielle—becomes the dominant memory cost. To keep memory bounded across a long stream, the caller should periodically clear the session, for example by committing (or flushing and calling `Session.expunge_all()`) at a cadence appropriate for the workload. etielle does not commit or expunge on your behalf, so transaction control stays with the caller.
+A SQLAlchemy `Session` tracks flushed instances in its identity map until the transaction ends or the instances are expunged. In streaming mode etielle expunges each component's flushed instances from the session after the chunk is flushed (the default `KeyCompleteFlushStrategy(evict_flushed=True)`), bounding the identity map to one component plus any resident `load_eager()` tables, which are deliberately never evicted.
+
+In practice the dominant memory win comes from streaming itself: etielle releases each chunk's accumulators before mapping the next, so peak heap stays flat regardless of dataset size (see `benchmarks/bench_issue_75.py`). Because SQLAlchemy's identity map references *persistent* instances weakly, CPython's garbage collector already reclaims them once etielle drops its references, so explicit eviction adds little measurable heap savings under the default session configuration. Its value is making the bound deterministic rather than GC-timing-dependent, and covering sessions configured to hold instances strongly or callers that retain references.
+
+Eviction is purely a memory concern and does **not** touch your transaction: the `INSERT`s remain in the open transaction, and commit/rollback stays the caller's responsibility. After you commit, the rows are queryable normally.
+
+Disable eviction with `flush_strategy=KeyCompleteFlushStrategy(evict_flushed=False)` if you need to keep working with the flushed ORM objects after the run, or if your models declare an aggressive `cascade` (e.g. `"all"`) on the child→parent direction that would detach resident eager parents:
+
+```python
+from etielle import stream, KeyCompleteFlushStrategy
+
+stream(chunks, flush_strategy=KeyCompleteFlushStrategy(evict_flushed=False))
+    ...
+```
+
+Resident `etl(...)` runs do not evict and keep today's behavior unchanged.
 
 ### Extending flush behavior
 

--- a/etielle/__init__.py
+++ b/etielle/__init__.py
@@ -39,6 +39,7 @@ from .instances import (
 # Fluent API (v3.0.0)
 from .fluent import (
     etl,
+    stream,
     ErrorMode,
     Field,
     TempField,
@@ -108,6 +109,7 @@ __all__ = [
     "FirstNonNullPolicy",
     # Fluent API (v3.0.0)
     "etl",
+    "stream",
     "ErrorMode",
     "Field",
     "TempField",
@@ -145,10 +147,32 @@ __all__ = [
 
 # relationships (core)
 from .relationships import ManyToOneSpec, compute_relationship_keys, bind_many_to_one
+from .relationships import RelationshipIncompleteError, validate_relationship_completeness
+from .executor import MappingRuntimeState
+from .chunking import (
+    Chunk,
+    ChunkSource,
+    FlushContext,
+    FlushStrategy,
+    KeyCompleteFlushStrategy,
+    OneRecordPerChunkSource,
+    CallableChunkSource,
+)
 
 __all__ += [
     # relationships
     "ManyToOneSpec",
     "compute_relationship_keys",
     "bind_many_to_one",
+    "RelationshipIncompleteError",
+    "validate_relationship_completeness",
+    # streaming/chunking
+    "Chunk",
+    "ChunkSource",
+    "FlushContext",
+    "FlushStrategy",
+    "KeyCompleteFlushStrategy",
+    "OneRecordPerChunkSource",
+    "CallableChunkSource",
+    "MappingRuntimeState",
 ]

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -1,0 +1,121 @@
+"""Chunking and flush strategy interfaces for streaming execution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from etielle.fluent import PipelineBuilder, TableStats
+    from etielle.telemetry import TelemetryCallback
+
+RootTuple = tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """A key-complete batch of JSON roots to map together.
+
+    Attributes:
+        roots: One or more JSON payloads for this chunk.
+        sequential: If True, every root is mapped against pipeline root index 0
+            with shared auto-key counters (group-by / repeated single-root records).
+            If False, root at position *i* maps to pipeline root index *i*
+            (multi-root ``goto_root()`` semantics).
+    """
+
+    roots: RootTuple
+    sequential: bool = False
+
+
+@runtime_checkable
+class ChunkSource(Protocol):
+    """Produces key-complete chunks for streaming execution."""
+
+    def chunks(self) -> Iterator[Chunk]:
+        """Yield chunks in traversal order."""
+        ...
+
+
+class OneRecordPerChunkSource:
+    """Wrap an iterable of JSON roots; each root becomes its own chunk."""
+
+    def __init__(self, records: Iterator[Any] | Sequence[Any]) -> None:
+        self._records = iter(records)
+
+    def chunks(self) -> Iterator[Chunk]:
+        for record in self._records:
+            yield Chunk(roots=(record,), sequential=True)
+
+
+class CallableChunkSource:
+    """Build chunks from a caller-supplied factory (tests and advanced callers)."""
+
+    def __init__(self, factory: Callable[[], Iterator[Chunk]]) -> None:
+        self._factory = factory
+
+    def chunks(self) -> Iterator[Chunk]:
+        yield from self._factory()
+
+
+@dataclass
+class FlushContext:
+    """Inputs for a flush at a component boundary."""
+
+    scope_tables: set[str]
+    bind_context: dict[str, Any]
+    local_results: dict[str, Any]
+    dep_graph: dict[str, set[str]]
+    link_to_rels: list[dict[str, Any]]
+    backlink_rels: list[dict[str, Any]]
+    stats: dict[str, TableStats]
+    on_event: TelemetryCallback | None
+    builder: PipelineBuilder = field(repr=False)
+
+
+@runtime_checkable
+class FlushStrategy(Protocol):
+    """Defines persistence behavior at a chunk/component boundary."""
+
+    def flush(self, ctx: FlushContext) -> None:
+        """Flush ``scope_tables`` using ``bind_context`` for relationship binding."""
+        ...
+
+
+class KeyCompleteFlushStrategy:
+    """Default streaming strategy: plain insert/flush, no cross-chunk merge."""
+
+    def flush(self, ctx: FlushContext) -> None:
+        builder = ctx.builder
+        if builder._session is None:
+            return
+        if builder._is_supabase_client(builder._session):
+            from etielle.utils import topological_sort
+
+            child_lookup = {
+                t: mr.lookup_values for t, mr in ctx.bind_context.items()
+            }
+            component_tables_dict = {
+                t: dict(ctx.local_results[t].instances)
+                for t in ctx.scope_tables
+                if t in ctx.local_results
+            }
+            component_order = topological_sort(ctx.dep_graph, ctx.scope_tables)
+            builder._flush_to_supabase(
+                component_tables_dict,
+                component_order,
+                child_lookup,
+                ctx.stats,
+                ctx.on_event,
+            )
+        else:
+            builder._flush_sqlalchemy_scope(
+                ctx.scope_tables,
+                ctx.bind_context,
+                ctx.dep_graph,
+                ctx.link_to_rels,
+                ctx.backlink_rels,
+                ctx.stats,
+                ctx.on_event,
+            )

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -82,9 +82,6 @@ class FlushContext:
     - ``stats`` / ``on_event``: stats accumulator and telemetry sink.
     - ``session``: the SQLAlchemy session or Supabase client from ``load()``.
     - ``is_supabase``: whether ``session`` is a Supabase client.
-    - ``evictable``: whether the scope's flushed instances may be released after
-      flushing. True for per-chunk components in streaming mode; False for
-      resident runs and for eager tables that must survive across chunks.
 
     ``builder`` is the engine handle that the built-in strategies use to reuse
     etielle's standard insert/bind logic. Custom strategies should rely on the
@@ -102,7 +99,6 @@ class FlushContext:
     on_event: TelemetryCallback | None
     session: Any
     is_supabase: bool
-    evictable: bool
     builder: PipelineBuilder = field(repr=False)
 
 
@@ -116,20 +112,7 @@ class FlushStrategy(Protocol):
 
 
 class KeyCompleteFlushStrategy:
-    """Default streaming strategy: plain insert/flush, no cross-chunk merge.
-
-    Args:
-        evict_flushed: When True (default), expunge a component's flushed ORM
-            instances from the SQLAlchemy session after each chunk so the
-            identity map stays bounded to one component plus resident eager
-            tables. Set False to keep flushed instances attached (e.g. when the
-            caller wants to keep working with them, or uses an aggressive
-            relationship cascade that would detach resident parents). Has no
-            effect on the Supabase path, which sends plain rows.
-    """
-
-    def __init__(self, *, evict_flushed: bool = True) -> None:
-        self.evict_flushed = evict_flushed
+    """Default streaming strategy: plain insert/flush, no cross-chunk merge."""
 
     def flush(self, ctx: FlushContext) -> None:
         if ctx.session is None:
@@ -162,5 +145,4 @@ class KeyCompleteFlushStrategy:
                 ctx.backlink_rels,
                 ctx.stats,
                 ctx.on_event,
-                evict=self.evict_flushed and ctx.evictable,
             )

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -39,10 +39,16 @@ class ChunkSource(Protocol):
 
 
 class OneRecordPerChunkSource:
-    """Wrap an iterable of JSON roots; each root becomes its own chunk."""
+    """Wrap an iterable of JSON roots; each root becomes its own chunk.
+
+    A re-iterable input (e.g. a list) can be streamed more than once. A
+    single-use iterator (e.g. a generator or an ``ijson`` stream) is consumed
+    on the first pass, matching the single-consumption nature of streaming
+    sources; running the pipeline again would yield no chunks.
+    """
 
     def __init__(self, records: Iterator[Any] | Sequence[Any]) -> None:
-        self._records = iter(records)
+        self._records = records
 
     def chunks(self) -> Iterator[Chunk]:
         for record in self._records:

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -67,7 +67,27 @@ class CallableChunkSource:
 
 @dataclass
 class FlushContext:
-    """Inputs for a flush at a component boundary."""
+    """Inputs for a flush at a component boundary.
+
+    The public fields provide everything a custom ``FlushStrategy`` needs to
+    persist a component without touching engine internals:
+
+    - ``scope_tables``: tables this flush is responsible for.
+    - ``bind_context``: mapped results for the scope plus any resident/eager
+      tables, used to resolve relationship parents.
+    - ``local_results``: mapped results scoped to ``scope_tables`` only.
+    - ``dep_graph``: child -> parents dependency graph (use
+      ``etielle.utils.topological_sort`` for flush order).
+    - ``link_to_rels`` / ``backlink_rels``: relationship specs in scope.
+    - ``stats`` / ``on_event``: stats accumulator and telemetry sink.
+    - ``session``: the SQLAlchemy session or Supabase client from ``load()``.
+    - ``is_supabase``: whether ``session`` is a Supabase client.
+
+    ``builder`` is the engine handle that the built-in strategies use to reuse
+    etielle's standard insert/bind logic. Custom strategies should rely on the
+    public fields above and implement their own persistence rather than calling
+    builder internals.
+    """
 
     scope_tables: set[str]
     bind_context: dict[str, Any]
@@ -77,6 +97,8 @@ class FlushContext:
     backlink_rels: list[dict[str, Any]]
     stats: dict[str, TableStats]
     on_event: TelemetryCallback | None
+    session: Any
+    is_supabase: bool
     builder: PipelineBuilder = field(repr=False)
 
 
@@ -93,10 +115,9 @@ class KeyCompleteFlushStrategy:
     """Default streaming strategy: plain insert/flush, no cross-chunk merge."""
 
     def flush(self, ctx: FlushContext) -> None:
-        builder = ctx.builder
-        if builder._session is None:
+        if ctx.session is None:
             return
-        if builder._is_supabase_client(builder._session):
+        if ctx.is_supabase:
             from etielle.utils import topological_sort
 
             child_lookup = {
@@ -108,7 +129,7 @@ class KeyCompleteFlushStrategy:
                 if t in ctx.local_results
             }
             component_order = topological_sort(ctx.dep_graph, ctx.scope_tables)
-            builder._flush_to_supabase(
+            ctx.builder._flush_to_supabase(
                 component_tables_dict,
                 component_order,
                 child_lookup,
@@ -116,7 +137,7 @@ class KeyCompleteFlushStrategy:
                 ctx.on_event,
             )
         else:
-            builder._flush_sqlalchemy_scope(
+            ctx.builder._flush_sqlalchemy_scope(
                 ctx.scope_tables,
                 ctx.bind_context,
                 ctx.dep_graph,

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -82,6 +82,9 @@ class FlushContext:
     - ``stats`` / ``on_event``: stats accumulator and telemetry sink.
     - ``session``: the SQLAlchemy session or Supabase client from ``load()``.
     - ``is_supabase``: whether ``session`` is a Supabase client.
+    - ``evictable``: whether the scope's flushed instances may be released after
+      flushing. True for per-chunk components in streaming mode; False for
+      resident runs and for eager tables that must survive across chunks.
 
     ``builder`` is the engine handle that the built-in strategies use to reuse
     etielle's standard insert/bind logic. Custom strategies should rely on the
@@ -99,6 +102,7 @@ class FlushContext:
     on_event: TelemetryCallback | None
     session: Any
     is_supabase: bool
+    evictable: bool
     builder: PipelineBuilder = field(repr=False)
 
 
@@ -112,7 +116,20 @@ class FlushStrategy(Protocol):
 
 
 class KeyCompleteFlushStrategy:
-    """Default streaming strategy: plain insert/flush, no cross-chunk merge."""
+    """Default streaming strategy: plain insert/flush, no cross-chunk merge.
+
+    Args:
+        evict_flushed: When True (default), expunge a component's flushed ORM
+            instances from the SQLAlchemy session after each chunk so the
+            identity map stays bounded to one component plus resident eager
+            tables. Set False to keep flushed instances attached (e.g. when the
+            caller wants to keep working with them, or uses an aggressive
+            relationship cascade that would detach resident parents). Has no
+            effect on the Supabase path, which sends plain rows.
+    """
+
+    def __init__(self, *, evict_flushed: bool = True) -> None:
+        self.evict_flushed = evict_flushed
 
     def flush(self, ctx: FlushContext) -> None:
         if ctx.session is None:
@@ -145,4 +162,5 @@ class KeyCompleteFlushStrategy:
                 ctx.backlink_rels,
                 ctx.stats,
                 ctx.on_event,
+                evict=self.evict_flushed and ctx.evictable,
             )

--- a/etielle/executor.py
+++ b/etielle/executor.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Tuple, Generator
+from dataclasses import dataclass, field
 from difflib import get_close_matches
 from .core import MappingSpec, Context, TraversalSpec, TableEmit, MappingResult, IterationLevel
 from .transforms import _iter_nodes, _resolve_path
@@ -6,6 +7,14 @@ from collections.abc import Mapping, Sequence, Iterable
 from .instances import InstanceEmit, resolve_field_name_for_builder
 
 KeyTuple = Tuple[Any, ...]
+
+
+@dataclass
+class MappingRuntimeState:
+    """Shared mapping state across multiple roots in one chunk."""
+
+    auto_key_counters: Dict[str, int] = field(default_factory=dict)
+
 
 # -----------------------------
 # Executor
@@ -213,6 +222,7 @@ def run_mapping(
     field_captures: Dict[str, Dict[str, Any]] | None = None,
     *,
     table_filter: set[str] | None = None,
+    runtime_state: MappingRuntimeState | None = None,
 ) -> Dict[str, MappingResult[Any]]:
     """
     Execute mapping spec against root JSON, returning rows per table.
@@ -231,18 +241,16 @@ def run_mapping(
         field_captures: Optional dict mapping table -> {field_name: transform} to
             capture during mapping for relationship binding (single-pass).
         table_filter: If set, only emit to tables in this set.
+        runtime_state: Optional shared state for auto-key counters across roots.
     """
     if linkable_fields is None:
         linkable_fields = {}
-    # For classic table rows (index by composite key)
+    state = runtime_state or MappingRuntimeState()
+    auto_key_counters = state.auto_key_counters
+
     table_to_index: Dict[str, Dict[Tuple[Any, ...], Dict[str, Any]]] = {}
     table_row_order: Dict[str, List[Tuple[Any, ...]]] = {}
-
-    # For instance emission
     instance_tables: Dict[str, Dict[str, Any]] = {}
-
-    # Auto-generated key counter for instances without join_on
-    auto_key_counters: Dict[str, int] = {}
 
     # Per-table lookup values captured during mapping {table: {key: {field: value}}}
     lookup_stores: Dict[str, Dict[KeyTuple, Dict[str, Any]]] = {}
@@ -365,6 +373,15 @@ def run_mapping(
         ordered_instances: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
         for key_tuple in ordered_keys:
             ordered_instances[key_tuple] = index[key_tuple]
+        indices: Dict[str, Dict[Any, Any]] = {}
+        for field_name in linkable_fields.get(table, set()):
+            field_index: Dict[Any, Any] = {}
+            for key_tuple, row in ordered_instances.items():
+                field_value = row.get(field_name)
+                if field_value is not None:
+                    field_index[field_value] = row
+            if field_index:
+                indices[field_name] = field_index
         outputs[table] = MappingResult(
             instances=ordered_instances,
             update_errors={},
@@ -374,6 +391,7 @@ def run_mapping(
                 "num_update_errors": 0,
                 "num_finalize_errors": 0,
             },
+            indices=indices,
             lookup_values=lookup_stores.get(table, {}),
         )
 

--- a/etielle/executor.py
+++ b/etielle/executor.py
@@ -373,15 +373,6 @@ def run_mapping(
         ordered_instances: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
         for key_tuple in ordered_keys:
             ordered_instances[key_tuple] = index[key_tuple]
-        indices: Dict[str, Dict[Any, Any]] = {}
-        for field_name in linkable_fields.get(table, set()):
-            field_index: Dict[Any, Any] = {}
-            for key_tuple, row in ordered_instances.items():
-                field_value = row.get(field_name)
-                if field_value is not None:
-                    field_index[field_value] = row
-            if field_index:
-                indices[field_name] = field_index
         outputs[table] = MappingResult(
             instances=ordered_instances,
             update_errors={},
@@ -391,7 +382,6 @@ def run_mapping(
                 "num_update_errors": 0,
                 "num_finalize_errors": 0,
             },
-            indices=indices,
             lookup_values=lookup_stores.get(table, {}),
         )
 

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -367,6 +367,14 @@ class PipelineBuilder:
         self._upsert_on: dict[str, str | list[str]] | None = None
         self._batch_size: int = 1000
 
+    def _get_flush_strategy(self) -> Any:
+        """Return the configured flush strategy, defaulting to KeyComplete."""
+        if self._flush_strategy is not None:
+            return self._flush_strategy
+        from etielle.chunking import KeyCompleteFlushStrategy
+
+        return KeyCompleteFlushStrategy()
+
     @staticmethod
     def _accumulate_stats(
         stats: dict[str, TableStats],
@@ -1404,15 +1412,19 @@ class PipelineBuilder:
         stats: dict[str, TableStats],
         on_event: TelemetryCallback | None,
     ) -> None:
-        """Emit mapping telemetry and update stats for mapped tables."""
+        """Emit mapping telemetry and update stats for mapped tables.
+
+        MapStarted/MapCompleted are emitted as a pair for each mapping pass. In
+        streaming mode a table is mapped once per chunk, so a pair is emitted per
+        chunk; stats accumulate across those passes.
+        """
         for table_name, mapping_result in raw_results.items():
             error_count = (
                 len(mapping_result.update_errors)
                 + len(mapping_result.finalize_errors)
             )
             instance_count = len(mapping_result.instances)
-            if table_name not in stats:
-                _emit(MapStarted(table=table_name), on_event)
+            _emit(MapStarted(table=table_name), on_event)
             _emit(
                 MapCompleted(
                     table=table_name,
@@ -1638,12 +1650,6 @@ class PipelineBuilder:
                 emits=(),
             )
 
-            if self._streaming:
-                raise ValueError(
-                    "Traversal-based build_index() is not supported in streaming mode; "
-                    "use build_index(name, from_dict=...) with a pre-built index instead."
-                )
-
             root = self._roots[build["root_index"]]
             index_data: dict[Any, Any] = {}
             for ctx in _iter_traversal_nodes(root, temp_spec):
@@ -1656,8 +1662,6 @@ class PipelineBuilder:
     def _prepare_execution(self) -> dict[str, Any]:
         """Compute shared execution metadata for resident and streaming runs."""
         from etielle.utils import partition_components
-
-        self._build_traversal_indices()
 
         linkable_fields = self._get_linkable_fields()
         captured_fields = self._get_captured_fields()
@@ -1762,11 +1766,9 @@ class PipelineBuilder:
         )
 
         if self._session is not None:
-            strategy = self._flush_strategy
-            from etielle.chunking import FlushContext, KeyCompleteFlushStrategy
+            from etielle.chunking import FlushContext
 
-            if strategy is None:
-                strategy = KeyCompleteFlushStrategy()
+            strategy = self._get_flush_strategy()
             ctx = FlushContext(
                 scope_tables=eager_tables,
                 bind_context=resident_results,
@@ -1776,6 +1778,8 @@ class PipelineBuilder:
                 backlink_rels=prepared["backlink_rels"],
                 stats=stats,
                 on_event=on_event,
+                session=self._session,
+                is_supabase=self._is_supabase_client(self._session),
                 builder=self,
             )
             if self._is_supabase_client(self._session):
@@ -1825,7 +1829,7 @@ class PipelineBuilder:
         map_first: bool = True,
     ) -> None:
         """Map (optional), bind, flush, and collect errors for one component."""
-        from etielle.chunking import FlushContext, KeyCompleteFlushStrategy
+        from etielle.chunking import FlushContext
 
         component_results = local_results
         if map_first:
@@ -1845,7 +1849,7 @@ class PipelineBuilder:
         )
 
         if self._session is not None:
-            strategy = self._flush_strategy or KeyCompleteFlushStrategy()
+            strategy = self._get_flush_strategy()
             ctx = FlushContext(
                 scope_tables=component,
                 bind_context=bind_context,
@@ -1855,6 +1859,8 @@ class PipelineBuilder:
                 backlink_rels=prepared["backlink_rels"],
                 stats=stats,
                 on_event=on_event,
+                session=self._session,
+                is_supabase=self._is_supabase_client(self._session),
                 builder=self,
             )
             strategy.flush(ctx)
@@ -1993,6 +1999,7 @@ class PipelineBuilder:
         """
         prepared = self._prepare_execution()
         self._validate_streaming_pipeline(prepared)
+        self._build_traversal_indices()
 
         if self._streaming:
             return self._run_streaming(prepared, on_event)
@@ -2084,7 +2091,7 @@ def stream(
     Returns:
         A ``PipelineBuilder`` for chaining navigation and mapping calls.
     """
-    from etielle.chunking import ChunkSource, KeyCompleteFlushStrategy, OneRecordPerChunkSource
+    from etielle.chunking import ChunkSource, OneRecordPerChunkSource
 
     chunk_source = source
     if not isinstance(source, ChunkSource):
@@ -2094,13 +2101,12 @@ def stream(
     if eager_roots is not None:
         eager = eager_roots if isinstance(eager_roots, tuple) else (eager_roots,)
 
-    strategy = flush_strategy or KeyCompleteFlushStrategy()
     return PipelineBuilder(
         eager,
         errors,
         indices,
         chunk_source=chunk_source,
-        flush_strategy=strategy,
+        flush_strategy=flush_strategy,
         streaming=True,
     )
 

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -336,9 +336,16 @@ class PipelineBuilder:
         roots: tuple[Any, ...],
         error_mode: ErrorMode = "collect",
         indices: dict[str, dict[Any, Any]] | None = None,
+        *,
+        chunk_source: Any | None = None,
+        flush_strategy: Any | None = None,
+        streaming: bool = False,
     ) -> None:
         self._roots = roots
         self._error_mode = error_mode
+        self._chunk_source = chunk_source
+        self._flush_strategy = flush_strategy
+        self._streaming = streaming
         # Index registry for lookup transforms
         self._indices: dict[str, dict[Any, Any]] = {
             k: dict(v) for k, v in (indices or {}).items()
@@ -360,6 +367,27 @@ class PipelineBuilder:
         self._upsert_on: dict[str, str | list[str]] | None = None
         self._batch_size: int = 1000
 
+    @staticmethod
+    def _accumulate_stats(
+        stats: dict[str, TableStats],
+        table: str,
+        *,
+        mapped: int = 0,
+        errors: int = 0,
+        inserted: int = 0,
+        failed: int = 0,
+    ) -> None:
+        """Additively update per-table stats (used across chunk boundaries)."""
+        if table not in stats:
+            stats[table] = TableStats(mapped=0, errors=0, inserted=0, failed=0)
+        prev = stats[table]
+        stats[table] = TableStats(
+            mapped=prev.mapped + mapped,
+            errors=prev.errors + errors,
+            inserted=prev.inserted + inserted,
+            failed=prev.failed + failed,
+        )
+
     def goto_root(self, index: int = 0) -> PipelineBuilder:
         """Navigate to a specific JSON root.
 
@@ -379,7 +407,9 @@ class PipelineBuilder:
             .goto_root(0).goto("users").each()  # Process users
             .goto_root(1).goto("posts").each()  # Process posts
         """
-        if index < 0 or index >= len(self._roots):
+        if index < 0:
+            raise IndexError(f"Root index {index} out of range")
+        if not self._streaming and index >= len(self._roots):
             raise IndexError(f"Root index {index} out of range (have {len(self._roots)} roots)")
         self._current_root_index = index
         self._current_path = []
@@ -866,9 +896,9 @@ class PipelineBuilder:
                 )
                 # Update stats
                 if table_name in stats:
-                    stats[table_name] = TableStats(
-                        mapped=stats[table_name].mapped,
-                        errors=stats[table_name].errors,
+                    self._accumulate_stats(
+                        stats,
+                        table_name,
                         inserted=table_inserted,
                         failed=len(rows) - table_inserted,
                     )
@@ -883,10 +913,9 @@ class PipelineBuilder:
                 )
                 # Update stats to show all rows failed
                 if table_name in stats:
-                    stats[table_name] = TableStats(
-                        mapped=stats[table_name].mapped,
-                        errors=stats[table_name].errors,
-                        inserted=0,
+                    self._accumulate_stats(
+                        stats,
+                        table_name,
                         failed=len(rows),
                     )
                 raise
@@ -1246,16 +1275,21 @@ class PipelineBuilder:
             existing.indices.setdefault(field_name, {}).update(index)
         existing.lookup_values.update(incoming.lookup_values)
 
-    def _map_tables(
+    def _map_roots(
         self,
+        roots: tuple[Any, ...],
         target_tables: set[str],
         linkable_fields: dict[str, set[str]],
         field_captures: dict[str, dict[Any, Any]],
+        *,
+        sequential: bool = False,
+        runtime_state: Any | None = None,
     ) -> dict[str, Any]:
-        """Run mapping for emissions targeting the given tables."""
+        """Run mapping for emissions targeting the given tables against roots."""
         from etielle.core import MappingSpec
-        from etielle.executor import run_mapping
+        from etielle.executor import MappingRuntimeState, run_mapping
 
+        state = runtime_state or MappingRuntimeState()
         emissions_by_root: dict[int, list[dict[str, Any]]] = {}
         for emission in self._emissions:
             if emission["table"] not in target_tables:
@@ -1263,27 +1297,95 @@ class PipelineBuilder:
             emissions_by_root.setdefault(emission["root_index"], []).append(emission)
 
         all_raw_results: dict[str, Any] = {}
-        for root_idx in sorted(emissions_by_root.keys()):
-            emissions = emissions_by_root[root_idx]
-            specs = self._build_specs_for_emissions(emissions)
-            mapping_spec = MappingSpec(traversals=tuple(specs))
-            root = self._roots[root_idx]
-            raw_results = run_mapping(
-                root,
-                mapping_spec,
-                linkable_fields=linkable_fields,
-                context_slots={"__indices__": self._indices},
-                field_captures=field_captures,
-                table_filter=target_tables,
-            )
-            for table_name, mapping_result in raw_results.items():
-                if table_name not in all_raw_results:
-                    all_raw_results[table_name] = mapping_result
-                else:
-                    self._merge_mapping_results(
-                        all_raw_results[table_name], mapping_result
+        root_indices = sorted(emissions_by_root.keys())
+        if sequential:
+            if not roots:
+                return all_raw_results
+            sequential_indices = [idx for idx in root_indices if idx == 0]
+            if not sequential_indices:
+                sequential_indices = [root_indices[0]]
+            specs_by_root = {
+                idx: self._build_specs_for_emissions(emissions_by_root[idx])
+                for idx in sequential_indices
+            }
+            for root in roots:
+                for root_idx in sequential_indices:
+                    specs = specs_by_root[root_idx]
+                    mapping_spec = MappingSpec(traversals=tuple(specs))
+                    raw_results = run_mapping(
+                        root,
+                        mapping_spec,
+                        linkable_fields=linkable_fields,
+                        context_slots={"__indices__": self._indices},
+                        field_captures=field_captures,
+                        table_filter=target_tables,
+                        runtime_state=state,
                     )
+                    for table_name, mapping_result in raw_results.items():
+                        if table_name not in all_raw_results:
+                            all_raw_results[table_name] = mapping_result
+                        else:
+                            self._merge_mapping_results(
+                                all_raw_results[table_name], mapping_result
+                            )
+        else:
+            for root_idx in root_indices:
+                if root_idx >= len(roots):
+                    continue
+                emissions = emissions_by_root[root_idx]
+                specs = self._build_specs_for_emissions(emissions)
+                mapping_spec = MappingSpec(traversals=tuple(specs))
+                root = roots[root_idx]
+                raw_results = run_mapping(
+                    root,
+                    mapping_spec,
+                    linkable_fields=linkable_fields,
+                    context_slots={"__indices__": self._indices},
+                    field_captures=field_captures,
+                    table_filter=target_tables,
+                    runtime_state=state,
+                )
+                for table_name, mapping_result in raw_results.items():
+                    if table_name not in all_raw_results:
+                        all_raw_results[table_name] = mapping_result
+                    else:
+                        self._merge_mapping_results(
+                            all_raw_results[table_name], mapping_result
+                        )
         return all_raw_results
+
+    def _map_tables(
+        self,
+        target_tables: set[str],
+        linkable_fields: dict[str, set[str]],
+        field_captures: dict[str, dict[Any, Any]],
+    ) -> dict[str, Any]:
+        """Run mapping for emissions targeting the given tables."""
+        return self._map_roots(
+            self._roots,
+            target_tables,
+            linkable_fields,
+            field_captures,
+        )
+
+    def _map_chunk(
+        self,
+        chunk: Any,
+        linkable_fields: dict[str, set[str]],
+        field_captures: dict[str, dict[Any, Any]],
+        emission_tables: set[str],
+    ) -> dict[str, Any]:
+        """Map all roots in a streaming chunk into one accumulator."""
+        from etielle.executor import MappingRuntimeState
+
+        return self._map_roots(
+            chunk.roots,
+            emission_tables,
+            linkable_fields,
+            field_captures,
+            sequential=chunk.sequential,
+            runtime_state=MappingRuntimeState(),
+        )
 
     def _record_mapping_stats(
         self,
@@ -1293,14 +1395,13 @@ class PipelineBuilder:
     ) -> None:
         """Emit mapping telemetry and update stats for mapped tables."""
         for table_name, mapping_result in raw_results.items():
-            if table_name in stats:
-                continue
-            _emit(MapStarted(table=table_name), on_event)
             error_count = (
                 len(mapping_result.update_errors)
                 + len(mapping_result.finalize_errors)
             )
             instance_count = len(mapping_result.instances)
+            if table_name not in stats:
+                _emit(MapStarted(table=table_name), on_event)
             _emit(
                 MapCompleted(
                     table=table_name,
@@ -1309,11 +1410,11 @@ class PipelineBuilder:
                 ),
                 on_event,
             )
-            stats[table_name] = TableStats(
+            self._accumulate_stats(
+                stats,
+                table_name,
                 mapped=instance_count,
                 errors=error_count,
-                inserted=0,
-                failed=0,
             )
 
     def _collect_errors(
@@ -1450,11 +1551,10 @@ class PipelineBuilder:
                     on_event,
                 )
                 if table_name in stats:
-                    stats[table_name] = TableStats(
-                        mapped=stats[table_name].mapped,
-                        errors=stats[table_name].errors,
+                    self._accumulate_stats(
+                        stats,
+                        table_name,
                         inserted=row_count,
-                        failed=0,
                     )
             except Exception as e:
                 _emit(
@@ -1466,10 +1566,9 @@ class PipelineBuilder:
                     on_event,
                 )
                 if table_name in stats:
-                    stats[table_name] = TableStats(
-                        mapped=stats[table_name].mapped,
-                        errors=stats[table_name].errors,
-                        inserted=0,
+                    self._accumulate_stats(
+                        stats,
+                        table_name,
                         failed=row_count,
                     )
                 raise
@@ -1494,30 +1593,11 @@ class PipelineBuilder:
             )
             self._session.flush()
 
-    def run(
-        self,
-        *,
-        on_event: TelemetryCallback | None = None,
-    ) -> PipelineResult:
-        """Execute the pipeline and return results.
-
-        If load() was called, also persists to the database.
-
-        Args:
-            on_event: Optional callback for telemetry events. Called with
-                MapStarted, MapCompleted, FlushStarted, FlushCompleted, or
-                FlushFailed events during pipeline execution.
-
-        Returns:
-            PipelineResult with tables, errors, and stats. When load() was
-            configured, flushed instances are not retained in result.tables
-            (stats and errors are always returned).
-        """
+    def _build_traversal_indices(self) -> None:
+        """Build traversal-based lookup indices before mapping."""
         from etielle.core import TraversalSpec
         from etielle.executor import _iter_traversal_nodes
-        from etielle.utils import partition_components, topological_sort
 
-        # Build indices from traversal specs before main execution
         for build in self._index_builds:
             index_name = build["name"]
             key_transform = build["key"]
@@ -1543,6 +1623,12 @@ class PipelineBuilder:
                 emits=(),
             )
 
+            if self._streaming:
+                raise ValueError(
+                    "Traversal-based build_index() is not supported in streaming mode; "
+                    "use build_index(name, from_dict=...) with a pre-built index instead."
+                )
+
             root = self._roots[build["root_index"]]
             index_data: dict[Any, Any] = {}
             for ctx in _iter_traversal_nodes(root, temp_spec):
@@ -1552,10 +1638,15 @@ class PipelineBuilder:
                     index_data[k] = v
             self._indices[index_name] = index_data
 
+    def _prepare_execution(self) -> dict[str, Any]:
+        """Compute shared execution metadata for resident and streaming runs."""
+        from etielle.utils import partition_components
+
+        self._build_traversal_indices()
+
         linkable_fields = self._get_linkable_fields()
         captured_fields = self._get_captured_fields()
         field_captures = self._build_field_captures(captured_fields)
-
         emission_tables = {e["table"] for e in self._emissions}
         eager_tables = set(self._eager_tables)
         dep_graph = self._build_dependency_graph()
@@ -1573,140 +1664,262 @@ class PipelineBuilder:
                 "which is only available with SQLAlchemy/SQLModel."
             )
 
-        stats: dict[str, TableStats] = {}
-        all_errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
-        result_tables: dict[str, dict[tuple[Any, ...], Any]] = {}
-        result_raw_results: dict[str, Any] | None = {} if self._session is None else None
-        retain_instances = self._session is None
-
-        # Resident eager tables kept for cross-component binding
-        resident_results: dict[str, Any] = {}
-
-        if eager_tables:
-            eager_results = self._map_tables(
-                eager_tables, linkable_fields, field_captures
-            )
-            self._record_mapping_stats(eager_results, stats, on_event)
-            resident_results.update(eager_results)
-
-            bind_scope = set(eager_results.keys())
-            self._bind_relationships_in_scope(
-                resident_results, link_to_rels, backlink_rels, bind_scope
-            )
-
-            if self._session is not None:
-                if self._is_supabase_client(self._session):
-                    if backlink_rels:
-                        raise ValueError(
-                            "backlink() is not supported with Supabase. "
-                            "backlink() relies on ORM-native many-to-many handling "
-                            "which is only available with SQLAlchemy/SQLModel."
-                        )
-                    child_lookup = {
-                        t: mr.lookup_values for t, mr in resident_results.items()
-                    }
-                    eager_tables_dict = {
-                        t: dict(mr.instances)
-                        for t, mr in resident_results.items()
-                    }
-                    eager_order = topological_sort(dep_graph, eager_tables)
-                    self._flush_to_supabase(
-                        eager_tables_dict,
-                        eager_order,
-                        child_lookup,
-                        stats,
-                        on_event,
-                    )
-                else:
-                    for rel in self._relationships:
-                        if rel.get("fk"):
-                            import warnings
-
-                            warnings.warn(
-                                f"fk parameter on link_to() is only supported for Supabase. "
-                                f"Ignoring fk={rel['fk']} for {rel['child_table']} -> {rel['parent_table']}.",
-                                UserWarning,
-                                stacklevel=2,
-                            )
-                    self._flush_sqlalchemy_scope(
-                        eager_tables,
-                        resident_results,
-                        dep_graph,
-                        link_to_rels,
-                        backlink_rels,
-                        stats,
-                        on_event,
-                    )
-            elif retain_instances:
-                for table_name, mapping_result in eager_results.items():
-                    result_tables[table_name] = dict(mapping_result.instances)
-                if result_raw_results is not None:
-                    result_raw_results.update(eager_results)
-
-            eager_errors = self._collect_errors(eager_results)
-            for table_name, table_errors in eager_errors.items():
-                all_errors.setdefault(table_name, {}).update(table_errors)
-
         components = partition_components(dep_graph, emission_tables, eager_tables)
 
-        for component in components:
+        return {
+            "linkable_fields": linkable_fields,
+            "field_captures": field_captures,
+            "emission_tables": emission_tables,
+            "eager_tables": eager_tables,
+            "dep_graph": dep_graph,
+            "link_to_rels": link_to_rels,
+            "backlink_rels": backlink_rels,
+            "components": components,
+        }
+
+    def _validate_streaming_pipeline(self, prepared: dict[str, Any]) -> None:
+        """Reject pipeline configurations incompatible with streaming."""
+        if not self._streaming:
+            return
+        if self._session is None:
+            raise ValueError(
+                "Streaming execution requires load(); collecting all streamed rows "
+                "would defeat streaming memory bounds."
+            )
+        for build in self._index_builds:
+            if build.get("key") is not None and build.get("value") is not None:
+                raise ValueError(
+                    "Traversal-based build_index() is not supported in streaming mode."
+                )
+        for rel in prepared["link_to_rels"]:
+            if len(rel["by"]) != 1:
+                raise ValueError(
+                    "Streaming execution currently requires single-field by mappings "
+                    f"on link_to(); got {rel['by']!r} for {rel['child_table']!r}."
+                )
+
+    def _run_eager_phase(
+        self,
+        prepared: dict[str, Any],
+        stats: dict[str, TableStats],
+        on_event: TelemetryCallback | None,
+        *,
+        retain_instances: bool,
+        result_tables: dict[str, dict[tuple[Any, ...], Any]],
+        result_raw_results: dict[str, Any] | None,
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]],
+    ) -> dict[str, Any]:
+        """Map, bind, and flush eager tables; return resident results."""
+        eager_tables = prepared["eager_tables"]
+        resident_results: dict[str, Any] = {}
+        if not eager_tables:
+            return resident_results
+
+        eager_results = self._map_tables(
+            eager_tables,
+            prepared["linkable_fields"],
+            prepared["field_captures"],
+        )
+        self._record_mapping_stats(eager_results, stats, on_event)
+        resident_results.update(eager_results)
+
+        bind_scope = set(eager_results.keys())
+        self._bind_relationships_in_scope(
+            resident_results,
+            prepared["link_to_rels"],
+            prepared["backlink_rels"],
+            bind_scope,
+        )
+
+        if self._session is not None:
+            strategy = self._flush_strategy
+            from etielle.chunking import FlushContext, KeyCompleteFlushStrategy
+
+            if strategy is None:
+                strategy = KeyCompleteFlushStrategy()
+            ctx = FlushContext(
+                scope_tables=eager_tables,
+                bind_context=resident_results,
+                local_results=eager_results,
+                dep_graph=prepared["dep_graph"],
+                link_to_rels=prepared["link_to_rels"],
+                backlink_rels=prepared["backlink_rels"],
+                stats=stats,
+                on_event=on_event,
+                builder=self,
+            )
+            if self._is_supabase_client(self._session):
+                if prepared["backlink_rels"]:
+                    raise ValueError(
+                        "backlink() is not supported with Supabase. "
+                        "backlink() relies on ORM-native many-to-many handling "
+                        "which is only available with SQLAlchemy/SQLModel."
+                    )
+            else:
+                for rel in self._relationships:
+                    if rel.get("fk"):
+                        import warnings
+
+                        warnings.warn(
+                            f"fk parameter on link_to() is only supported for Supabase. "
+                            f"Ignoring fk={rel['fk']} for {rel['child_table']} -> {rel['parent_table']}.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+            strategy.flush(ctx)
+        elif retain_instances:
+            for table_name, mapping_result in eager_results.items():
+                result_tables[table_name] = dict(mapping_result.instances)
+            if result_raw_results is not None:
+                result_raw_results.update(eager_results)
+
+        eager_errors = self._collect_errors(eager_results)
+        for table_name, table_errors in eager_errors.items():
+            all_errors.setdefault(table_name, {}).update(table_errors)
+
+        return resident_results
+
+    def _run_component_cycle(
+        self,
+        component: set[str],
+        bind_context: dict[str, Any],
+        local_results: dict[str, Any],
+        prepared: dict[str, Any],
+        stats: dict[str, TableStats],
+        on_event: TelemetryCallback | None,
+        *,
+        retain_instances: bool,
+        result_tables: dict[str, dict[tuple[Any, ...], Any]],
+        result_raw_results: dict[str, Any] | None,
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]],
+        map_first: bool = True,
+    ) -> None:
+        """Map (optional), bind, flush, and collect errors for one component."""
+        from etielle.chunking import FlushContext, KeyCompleteFlushStrategy
+
+        component_results = local_results
+        if map_first:
             component_results = self._map_tables(
-                component, linkable_fields, field_captures
+                component,
+                prepared["linkable_fields"],
+                prepared["field_captures"],
             )
             self._record_mapping_stats(component_results, stats, on_event)
+            bind_context = {**bind_context, **component_results}
 
-            bind_context = {**resident_results, **component_results}
-            self._bind_relationships_in_scope(
-                bind_context, link_to_rels, backlink_rels, component
+        self._bind_relationships_in_scope(
+            bind_context,
+            prepared["link_to_rels"],
+            prepared["backlink_rels"],
+            component,
+        )
+
+        if self._session is not None:
+            strategy = self._flush_strategy or KeyCompleteFlushStrategy()
+            ctx = FlushContext(
+                scope_tables=component,
+                bind_context=bind_context,
+                local_results=component_results,
+                dep_graph=prepared["dep_graph"],
+                link_to_rels=prepared["link_to_rels"],
+                backlink_rels=prepared["backlink_rels"],
+                stats=stats,
+                on_event=on_event,
+                builder=self,
             )
-
-            if self._session is not None:
-                if self._is_supabase_client(self._session):
-                    child_lookup = {
-                        t: mr.lookup_values for t, mr in bind_context.items()
-                    }
-                    component_tables_dict = {
-                        t: dict(component_results[t].instances)
-                        for t in component
-                        if t in component_results
-                    }
-                    component_order = topological_sort(dep_graph, component)
-                    self._flush_to_supabase(
-                        component_tables_dict,
-                        component_order,
-                        child_lookup,
-                        stats,
-                        on_event,
-                    )
-                else:
-                    self._flush_sqlalchemy_scope(
-                        component,
-                        bind_context,
-                        dep_graph,
-                        link_to_rels,
-                        backlink_rels,
-                        stats,
-                        on_event,
-                    )
-            elif retain_instances:
+            strategy.flush(ctx)
+        elif retain_instances:
+            for table_name, mapping_result in component_results.items():
+                result_tables[table_name] = dict(mapping_result.instances)
+            if result_raw_results is not None:
                 for table_name, mapping_result in component_results.items():
-                    result_tables[table_name] = dict(mapping_result.instances)
-                if result_raw_results is not None:
-                    for table_name, mapping_result in component_results.items():
-                        if table_name not in result_raw_results:
-                            result_raw_results[table_name] = mapping_result
-                        else:
-                            self._merge_mapping_results(
-                                result_raw_results[table_name], mapping_result
-                            )
+                    if table_name not in result_raw_results:
+                        result_raw_results[table_name] = mapping_result
+                    else:
+                        self._merge_mapping_results(
+                            result_raw_results[table_name], mapping_result
+                        )
 
-            component_errors = self._collect_errors(component_results)
-            for table_name, table_errors in component_errors.items():
-                all_errors.setdefault(table_name, {}).update(table_errors)
+        component_errors = self._collect_errors(component_results)
+        for table_name, table_errors in component_errors.items():
+            all_errors.setdefault(table_name, {}).update(table_errors)
 
-            # Evict component-local accumulators
+        if map_first:
             component_results.clear()
 
+    def _run_streaming(
+        self,
+        prepared: dict[str, Any],
+        on_event: TelemetryCallback | None,
+    ) -> PipelineResult:
+        """Execute a streaming/chunked pipeline."""
+        from etielle.relationships import validate_relationship_completeness
+
+        stats: dict[str, TableStats] = {}
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
+
+        resident_results = self._run_eager_phase(
+            prepared,
+            stats,
+            on_event,
+            retain_instances=False,
+            result_tables={},
+            result_raw_results=None,
+            all_errors=all_errors,
+        )
+
+        non_eager_tables = prepared["emission_tables"] - prepared["eager_tables"]
+
+        for chunk in self._chunk_source.chunks():
+            chunk_results = self._map_chunk(
+                chunk,
+                prepared["linkable_fields"],
+                prepared["field_captures"],
+                non_eager_tables,
+            )
+            self._record_mapping_stats(chunk_results, stats, on_event)
+
+            bind_context = {**resident_results, **chunk_results}
+            validate_relationship_completeness(
+                bind_context,
+                prepared["link_to_rels"],
+                chunk_tables=set(chunk_results.keys()),
+                eager_tables=prepared["eager_tables"],
+            )
+
+            for component in prepared["components"]:
+                component_local = {
+                    t: chunk_results[t]
+                    for t in component
+                    if t in chunk_results
+                }
+                if not component_local:
+                    continue
+                self._run_component_cycle(
+                    component,
+                    bind_context,
+                    component_local,
+                    prepared,
+                    stats,
+                    on_event,
+                    retain_instances=False,
+                    result_tables={},
+                    result_raw_results=None,
+                    all_errors=all_errors,
+                    map_first=False,
+                )
+
+            chunk_results.clear()
+
+        return self._finalize_result(stats, all_errors, tables={})
+
+    def _finalize_result(
+        self,
+        stats: dict[str, TableStats],
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]],
+        tables: dict[str, dict[tuple[Any, ...], Any]],
+        result_raw_results: dict[str, Any] | None = None,
+    ) -> PipelineResult:
         table_class_map: dict[str, type] = {}
         for emission in self._emissions:
             if emission["table_class"]:
@@ -1722,11 +1935,75 @@ class PipelineBuilder:
                     raise ValueError(error_msg)
 
         return PipelineResult(
-            tables=result_tables,
+            tables=tables,
             errors=all_errors,
             _table_class_map=table_class_map,
             _raw_results=result_raw_results,
             _stats=stats,
+        )
+
+    def run(
+        self,
+        *,
+        on_event: TelemetryCallback | None = None,
+    ) -> PipelineResult:
+        """Execute the pipeline and return results.
+
+        If load() was called, also persists to the database.
+
+        Args:
+            on_event: Optional callback for telemetry events. Called with
+                MapStarted, MapCompleted, FlushStarted, FlushCompleted, or
+                FlushFailed events during pipeline execution.
+
+        Returns:
+            PipelineResult with tables, errors, and stats. When load() was
+            configured, flushed instances are not retained in result.tables
+            (stats and errors are always returned).
+        """
+        prepared = self._prepare_execution()
+        self._validate_streaming_pipeline(prepared)
+
+        if self._streaming:
+            return self._run_streaming(prepared, on_event)
+
+        stats: dict[str, TableStats] = {}
+        all_errors: dict[str, dict[tuple[Any, ...], list[str]]] = {}
+        result_tables: dict[str, dict[tuple[Any, ...], Any]] = {}
+        result_raw_results: dict[str, Any] | None = {} if self._session is None else None
+        retain_instances = self._session is None
+
+        resident_results = self._run_eager_phase(
+            prepared,
+            stats,
+            on_event,
+            retain_instances=retain_instances,
+            result_tables=result_tables,
+            result_raw_results=result_raw_results,
+            all_errors=all_errors,
+        )
+
+        for component in prepared["components"]:
+            component_results: dict[str, Any] = {}
+            self._run_component_cycle(
+                component,
+                {**resident_results},
+                component_results,
+                prepared,
+                stats,
+                on_event,
+                retain_instances=retain_instances,
+                result_tables=result_tables,
+                result_raw_results=result_raw_results,
+                all_errors=all_errors,
+                map_first=True,
+            )
+
+        return self._finalize_result(
+            stats,
+            all_errors,
+            result_tables,
+            result_raw_results,
         )
 
 
@@ -1752,3 +2029,50 @@ def etl(*roots: Any, errors: ErrorMode = "collect", indices: dict[str, dict[Any,
         )
     """
     return PipelineBuilder(roots, errors, indices)
+
+
+def stream(
+    source: Any,
+    *,
+    eager_roots: Any | tuple[Any, ...] | None = None,
+    flush_strategy: Any | None = None,
+    errors: ErrorMode = "collect",
+    indices: dict[str, dict[Any, Any]] | None = None,
+) -> PipelineBuilder:
+    """Entry point for streaming/chunked E→T→L pipelines.
+
+    Each chunk must be key-complete and relationship-complete. Streaming
+    execution requires ``load()`` before ``run()``.
+
+    Args:
+        source: A ``ChunkSource`` or iterable of JSON roots (one root per chunk).
+        eager_roots: Optional resident JSON root(s) for ``load_eager()`` tables.
+        flush_strategy: Optional flush strategy (defaults to ``KeyCompleteFlushStrategy``).
+        errors: Error handling mode - ``collect`` (default) or ``fail_fast``.
+        indices: Pre-built lookup indices for use with ``lookup()`` transform.
+
+    Returns:
+        A ``PipelineBuilder`` for chaining navigation and mapping calls.
+    """
+    from etielle.chunking import ChunkSource, KeyCompleteFlushStrategy, OneRecordPerChunkSource
+
+    chunk_source = source
+    if not isinstance(source, ChunkSource):
+        chunk_source = OneRecordPerChunkSource(source)
+
+    eager: tuple[Any, ...] = ()
+    if eager_roots is not None:
+        eager = eager_roots if isinstance(eager_roots, tuple) else (eager_roots,)
+
+    strategy = flush_strategy or KeyCompleteFlushStrategy()
+    return PipelineBuilder(
+        eager,
+        errors,
+        indices,
+        chunk_source=chunk_source,
+        flush_strategy=strategy,
+        streaming=True,
+    )
+
+
+etl.stream = stream

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1518,9 +1518,13 @@ class PipelineBuilder:
             row_count = len(tables[table_name])
             _emit(FlushStarted(table=table_name, count=row_count), on_event)
 
+            # Plain-dict rows are not ORM instances and are not persisted on the
+            # SQLAlchemy path; only count instances actually added to the session.
+            added_count = 0
             for _key, instance in tables[table_name].items():
                 if not isinstance(instance, dict):
                     self._session.add(instance)
+                    added_count += 1
 
             for idx, parent_table in pending_bindings.get(table_name, []):
                 if parent_table not in raw_results:
@@ -1553,7 +1557,7 @@ class PipelineBuilder:
                 _emit(
                     FlushCompleted(
                         table=table_name,
-                        inserted=row_count,
+                        inserted=added_count,
                         failed=0,
                         batch_num=1,
                         batch_total=1,
@@ -1565,14 +1569,14 @@ class PipelineBuilder:
                     self._accumulate_stats(
                         stats,
                         table_name,
-                        inserted=row_count,
+                        inserted=added_count,
                     )
             except Exception as e:
                 _emit(
                     FlushFailed(
                         table=table_name,
                         error=str(e),
-                        affected_count=row_count,
+                        affected_count=added_count,
                     ),
                     on_event,
                 )
@@ -1580,7 +1584,7 @@ class PipelineBuilder:
                     self._accumulate_stats(
                         stats,
                         table_name,
-                        failed=row_count,
+                        failed=added_count,
                     )
                 raise
 

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1503,18 +1503,8 @@ class PipelineBuilder:
         backlink_rels: list[dict[str, Any]],
         stats: dict[str, TableStats],
         on_event: TelemetryCallback | None,
-        *,
-        evict: bool = False,
     ) -> None:
-        """Flush tables in scope to SQLAlchemy session in dependency order.
-
-        When ``evict`` is True, the scope's flushed ORM instances are expunged
-        from the session after all binding and flushing completes. This bounds
-        the session identity map to one component (plus resident eager tables)
-        during streaming. Eager/resident tables are never passed in this scope,
-        so they survive across chunks. The just-emitted INSERTs remain in the
-        open transaction; caller-controlled commit/rollback is unaffected.
-        """
+        """Flush tables in scope to SQLAlchemy session in dependency order."""
         from etielle.utils import topological_sort
 
         tables = {
@@ -1629,14 +1619,6 @@ class PipelineBuilder:
                 fail_on_missing=False,
             )
             self._session.flush()
-
-        if evict:
-            for table_name in tables:
-                for instance in tables[table_name].values():
-                    if isinstance(instance, dict):
-                        continue
-                    if instance in self._session:
-                        self._session.expunge(instance)
 
     def _build_traversal_indices(self) -> None:
         """Build traversal-based lookup indices before mapping."""
@@ -1798,7 +1780,6 @@ class PipelineBuilder:
                 on_event=on_event,
                 session=self._session,
                 is_supabase=self._is_supabase_client(self._session),
-                evictable=False,
                 builder=self,
             )
             if self._is_supabase_client(self._session):
@@ -1880,7 +1861,6 @@ class PipelineBuilder:
                 on_event=on_event,
                 session=self._session,
                 is_supabase=self._is_supabase_client(self._session),
-                evictable=self._streaming,
                 builder=self,
             )
             strategy.flush(ctx)

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1503,8 +1503,18 @@ class PipelineBuilder:
         backlink_rels: list[dict[str, Any]],
         stats: dict[str, TableStats],
         on_event: TelemetryCallback | None,
+        *,
+        evict: bool = False,
     ) -> None:
-        """Flush tables in scope to SQLAlchemy session in dependency order."""
+        """Flush tables in scope to SQLAlchemy session in dependency order.
+
+        When ``evict`` is True, the scope's flushed ORM instances are expunged
+        from the session after all binding and flushing completes. This bounds
+        the session identity map to one component (plus resident eager tables)
+        during streaming. Eager/resident tables are never passed in this scope,
+        so they survive across chunks. The just-emitted INSERTs remain in the
+        open transaction; caller-controlled commit/rollback is unaffected.
+        """
         from etielle.utils import topological_sort
 
         tables = {
@@ -1619,6 +1629,14 @@ class PipelineBuilder:
                 fail_on_missing=False,
             )
             self._session.flush()
+
+        if evict:
+            for table_name in tables:
+                for instance in tables[table_name].values():
+                    if isinstance(instance, dict):
+                        continue
+                    if instance in self._session:
+                        self._session.expunge(instance)
 
     def _build_traversal_indices(self) -> None:
         """Build traversal-based lookup indices before mapping."""
@@ -1780,6 +1798,7 @@ class PipelineBuilder:
                 on_event=on_event,
                 session=self._session,
                 is_supabase=self._is_supabase_client(self._session),
+                evictable=False,
                 builder=self,
             )
             if self._is_supabase_client(self._session):
@@ -1861,6 +1880,7 @@ class PipelineBuilder:
                 on_event=on_event,
                 session=self._session,
                 is_supabase=self._is_supabase_client(self._session),
+                evictable=self._streaming,
                 builder=self,
             )
             strategy.flush(ctx)

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1298,40 +1298,57 @@ class PipelineBuilder:
 
         all_raw_results: dict[str, Any] = {}
         root_indices = sorted(emissions_by_root.keys())
+
+        def _absorb(raw_results: dict[str, Any]) -> None:
+            for table_name, mapping_result in raw_results.items():
+                if table_name not in all_raw_results:
+                    all_raw_results[table_name] = mapping_result
+                else:
+                    self._merge_mapping_results(
+                        all_raw_results[table_name], mapping_result
+                    )
+
         if sequential:
             if not roots:
                 return all_raw_results
-            sequential_indices = [idx for idx in root_indices if idx == 0]
-            if not sequential_indices:
-                sequential_indices = [root_indices[0]]
-            specs_by_root = {
-                idx: self._build_specs_for_emissions(emissions_by_root[idx])
-                for idx in sequential_indices
-            }
+            non_zero = [idx for idx in root_indices if idx != 0]
+            if non_zero:
+                raise ValueError(
+                    "Streaming sources that yield one record per chunk (sequential "
+                    "chunks) support only a single root, but the pipeline references "
+                    f"goto_root() index(es) {non_zero}. Either drop the multi-root "
+                    "goto_root() calls, or supply a ChunkSource that yields multi-root "
+                    "Chunks (sequential=False) so each goto_root() index maps to a "
+                    "distinct root in the chunk."
+                )
+            if 0 not in emissions_by_root:
+                return all_raw_results
+            specs = self._build_specs_for_emissions(emissions_by_root[0])
+            mapping_spec = MappingSpec(traversals=tuple(specs))
             for root in roots:
-                for root_idx in sequential_indices:
-                    specs = specs_by_root[root_idx]
-                    mapping_spec = MappingSpec(traversals=tuple(specs))
-                    raw_results = run_mapping(
-                        root,
-                        mapping_spec,
-                        linkable_fields=linkable_fields,
-                        context_slots={"__indices__": self._indices},
-                        field_captures=field_captures,
-                        table_filter=target_tables,
-                        runtime_state=state,
-                    )
-                    for table_name, mapping_result in raw_results.items():
-                        if table_name not in all_raw_results:
-                            all_raw_results[table_name] = mapping_result
-                        else:
-                            self._merge_mapping_results(
-                                all_raw_results[table_name], mapping_result
-                            )
+                raw_results = run_mapping(
+                    root,
+                    mapping_spec,
+                    linkable_fields=linkable_fields,
+                    context_slots={"__indices__": self._indices},
+                    field_captures=field_captures,
+                    table_filter=target_tables,
+                    runtime_state=state,
+                )
+                _absorb(raw_results)
         else:
             for root_idx in root_indices:
                 if root_idx >= len(roots):
-                    continue
+                    if self._streaming:
+                        raise ValueError(
+                            f"Chunk supplies {len(roots)} root(s) but the pipeline "
+                            f"references goto_root({root_idx}). Each multi-root chunk "
+                            "must provide a root for every goto_root() index used by "
+                            "the pipeline."
+                        )
+                    raise IndexError(
+                        f"Root index {root_idx} out of range (have {len(roots)} roots)"
+                    )
                 emissions = emissions_by_root[root_idx]
                 specs = self._build_specs_for_emissions(emissions)
                 mapping_spec = MappingSpec(traversals=tuple(specs))
@@ -1345,13 +1362,7 @@ class PipelineBuilder:
                     table_filter=target_tables,
                     runtime_state=state,
                 )
-                for table_name, mapping_result in raw_results.items():
-                    if table_name not in all_raw_results:
-                        all_raw_results[table_name] = mapping_result
-                    else:
-                        self._merge_mapping_results(
-                            all_raw_results[table_name], mapping_result
-                        )
+                _absorb(raw_results)
         return all_raw_results
 
     def _map_tables(
@@ -1697,6 +1708,21 @@ class PipelineBuilder:
                     "Streaming execution currently requires single-field by mappings "
                     f"on link_to(); got {rel['by']!r} for {rel['child_table']!r}."
                 )
+
+        from etielle.chunking import OneRecordPerChunkSource
+
+        referenced_indices = {e["root_index"] for e in self._emissions}
+        multi_root_indices = sorted(i for i in referenced_indices if i > 0)
+        if multi_root_indices and isinstance(
+            self._chunk_source, OneRecordPerChunkSource
+        ):
+            raise ValueError(
+                "This pipeline references goto_root() index(es) "
+                f"{multi_root_indices}, which requires multi-root chunks, but the "
+                "streaming source yields one root per chunk. Pass a ChunkSource that "
+                "yields multi-root Chunks (sequential=False), or remove the "
+                "multi-root goto_root() calls."
+            )
 
     def _run_eager_phase(
         self,

--- a/etielle/relationships.py
+++ b/etielle/relationships.py
@@ -577,18 +577,24 @@ def validate_relationship_completeness(
         child_field, parent_field = next(iter(by_mapping.items()))
         lookup_values = child_result.lookup_values
 
+        # Build the set of parent key values present in this scope. Using the
+        # captured lookup_values (rather than secondary indices) keeps this
+        # correct for every emit type, including plain-dict tables and
+        # TempField-keyed joins where no instance-level index exists.
+        parent_values_present: set[Any] = set()
+        if parent_result is not None:
+            for parent_vals in parent_result.lookup_values.values():
+                value = parent_vals.get(parent_field)
+                if value is not None:
+                    parent_values_present.add(value)
+
         for child_key, _child_obj in child_result.instances.items():
             child_values = lookup_values.get(child_key, {})
             lookup_value = child_values.get(child_field)
             if lookup_value is None:
                 continue
 
-            parent_obj = None
-            if parent_result is not None:
-                parent_index = parent_result.indices.get(parent_field, {})
-                parent_obj = parent_index.get(lookup_value)
-
-            if parent_obj is None:
+            if lookup_value not in parent_values_present:
                 hint = (
                     f"Use a coarser chunk key or mark {parent_table!r} as load_eager()."
                 )

--- a/etielle/relationships.py
+++ b/etielle/relationships.py
@@ -536,3 +536,75 @@ def bind_relationships_via_index(
         )
 
     return all_errors
+
+
+class RelationshipIncompleteError(RuntimeError):
+    """Raised when a chunk lacks a required relationship target."""
+
+
+def validate_relationship_completeness(
+    raw_results: Mapping[str, MappingResult[Any]],
+    relationships: Sequence[dict[str, Any]],
+    *,
+    chunk_tables: set[str],
+    eager_tables: set[str],
+) -> None:
+    """Ensure every child lookup in the chunk resolves within chunk or eager tables."""
+    errors: list[str] = []
+
+    for rel in relationships:
+        if rel.get("type") == "backlink":
+            continue
+
+        by_mapping = rel["by"]
+        if len(by_mapping) != 1:
+            errors.append(
+                "Streaming relationship validation currently requires single-field "
+                f"by mappings; got {by_mapping!r} on {rel['child_table']!r}"
+            )
+            continue
+
+        child_table = rel["child_table"]
+        parent_table = rel["parent_table"]
+        if child_table not in chunk_tables:
+            continue
+
+        child_result = raw_results.get(child_table)
+        parent_result = raw_results.get(parent_table)
+        if child_result is None:
+            continue
+
+        child_field, parent_field = next(iter(by_mapping.items()))
+        lookup_values = child_result.lookup_values
+
+        for child_key, _child_obj in child_result.instances.items():
+            child_values = lookup_values.get(child_key, {})
+            lookup_value = child_values.get(child_field)
+            if lookup_value is None:
+                continue
+
+            parent_obj = None
+            if parent_result is not None:
+                parent_index = parent_result.indices.get(parent_field, {})
+                parent_obj = parent_index.get(lookup_value)
+
+            if parent_obj is None:
+                hint = (
+                    f"Use a coarser chunk key or mark {parent_table!r} as load_eager()."
+                )
+                if parent_table not in chunk_tables and parent_table not in eager_tables:
+                    hint = (
+                        f"Parent table {parent_table!r} is not in this chunk or eager "
+                        f"tables {sorted(eager_tables)}. {hint}"
+                    )
+                errors.append(
+                    f"Child table {child_table!r} key={child_key} references parent "
+                    f"table {parent_table!r} via {child_field}={lookup_value!r}, "
+                    f"but no matching parent exists in this chunk or eager tables. "
+                    f"{hint}"
+                )
+
+    if errors:
+        raise RelationshipIncompleteError(
+            "Chunk is not relationship-complete:\n" + "\n".join(errors)
+        )

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -1,0 +1,486 @@
+"""Tests for issue #75: streaming + chunked execution (key-complete contract)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from etielle import Field, TempField, etl, get, stream
+from etielle.chunking import (
+    CallableChunkSource,
+    Chunk,
+    FlushContext,
+    KeyCompleteFlushStrategy,
+    OneRecordPerChunkSource,
+)
+from etielle.instances import AddPolicy
+from etielle.relationships import RelationshipIncompleteError
+
+
+Base = declarative_base()
+
+
+class StreamUser(Base):
+    __tablename__ = "stream_users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class StreamPost(Base):
+    __tablename__ = "stream_posts"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    user_id = Column(Integer, ForeignKey("stream_users.id"))
+
+
+class StreamTag(Base):
+    __tablename__ = "stream_tags"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class StreamItem(Base):
+    __tablename__ = "stream_items"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    tag_id = Column(Integer, ForeignKey("stream_tags.id"))
+
+
+class StreamSale(Base):
+    __tablename__ = "stream_sales"
+    id = Column(Integer, primary_key=True)
+    product = Column(String)
+    total = Column(Integer)
+
+
+@dataclass
+class Parent:
+    id: str
+
+
+@dataclass
+class Child:
+    id: str
+    parent: Parent | None = None
+
+
+class TestStreamingRequiresLoad:
+    def test_stream_without_load_raises(self):
+        builder = (
+            stream([{"users": []}])
+            .goto("users")
+            .each()
+            .map_to(table="users", fields=[Field("name", get("name"))])
+        )
+        with pytest.raises(ValueError, match="requires load"):
+            builder.run()
+
+
+class TestResidentParity:
+    def test_chunked_equals_resident(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        combined = {
+            "users": [
+                {"id": 1, "name": "Alice"},
+                {"id": 2, "name": "Bob"},
+            ],
+            "posts": [
+                {"id": 10, "title": "Hello", "user_id": 1},
+                {"id": 11, "title": "World", "user_id": 2},
+            ],
+        }
+
+        resident = (
+            etl(combined)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("posts")
+            .each()
+            .map_to(
+                table=StreamPost,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(StreamUser, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+        session.close()
+
+        engine2 = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine2)
+        Session2 = sessionmaker(bind=engine2)
+        session2 = Session2()
+
+        chunks = [
+            {
+                "users": [{"id": 1, "name": "Alice"}],
+                "posts": [{"id": 10, "title": "Hello", "user_id": 1}],
+            },
+            {
+                "users": [{"id": 2, "name": "Bob"}],
+                "posts": [{"id": 11, "title": "World", "user_id": 2}],
+            },
+        ]
+
+        streamed = (
+            stream(chunks)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("posts")
+            .each()
+            .map_to(
+                table=StreamPost,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(StreamUser, by={"user_id": "id"})
+            .load(session2)
+            .run()
+        )
+        session2.commit()
+
+        assert resident.stats["stream_users"].inserted == 2
+        assert resident.stats["stream_posts"].inserted == 2
+        assert streamed.stats["stream_users"].inserted == 2
+        assert streamed.stats["stream_posts"].inserted == 2
+        assert session2.query(StreamUser).count() == 2
+        assert session2.query(StreamPost).count() == 2
+        session2.close()
+
+
+class TestAutoKeySafety:
+    def test_auto_keys_do_not_collide_in_chunk(self):
+        records = [
+            {"items": [{"name": "a"}]},
+            {"items": [{"name": "b"}]},
+            {"items": [{"name": "c"}]},
+        ]
+
+        result = (
+            stream(
+                CallableChunkSource(
+                    lambda: iter([Chunk(roots=tuple(records), sequential=True)])
+                )
+            )
+            .goto("items")
+            .each()
+            .map_to(table="items", fields=[Field("name", get("name"))])
+            .load(sessionmaker(bind=create_engine("sqlite:///:memory:"))())
+            .run()
+        )
+
+        assert result.stats["items"].mapped == 3
+        assert result.stats["items"].inserted == 3
+
+
+class TestStatsAggregation:
+    def test_cumulative_stats_across_chunks(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        chunks = [
+            {"users": [{"id": 1, "name": "A"}]},
+            {"users": [{"id": 2, "name": "B"}]},
+            {"users": [{"id": 3, "name": "C"}]},
+        ]
+
+        result = (
+            stream(chunks)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert result.stats["stream_users"].mapped == 3
+        assert result.stats["stream_users"].inserted == 3
+        session.close()
+
+
+class TestWithinChunkMerge:
+    def test_merge_policy_within_single_chunk_root(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        chunk_root = {
+            "sales": [
+                {"product": "Widget", "amount": 100},
+                {"product": "Widget", "amount": 50},
+            ]
+        }
+
+        (
+            stream([chunk_root])
+            .goto("sales")
+            .each()
+            .map_to(
+                table=StreamSale,
+                join_on=["product"],
+                fields=[
+                    Field("product", get("product")),
+                    Field("total", get("amount"), merge=AddPolicy()),
+                    TempField("id", get("amount")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        rows = session.query(StreamSale).all()
+        assert len(rows) == 1
+        assert rows[0].total == 150
+        session.close()
+
+
+class TestRelationshipCompleteness:
+    def test_incomplete_chunk_raises(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        with pytest.raises(RelationshipIncompleteError, match="relationship-complete"):
+            (
+                stream([{"posts": [{"id": 1, "title": "x", "user_id": 99}]}])
+                .goto("posts")
+                .each()
+                .map_to(
+                    table=StreamPost,
+                    fields=[
+                        Field("title", get("title")),
+                        TempField("id", get("id")),
+                        TempField("user_id", get("user_id")),
+                    ],
+                )
+                .link_to(StreamUser, by={"user_id": "id"})
+                .load(session)
+                .run()
+            )
+        session.close()
+
+    def test_complete_chunk_succeeds(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        chunk = {
+            "users": [{"id": 1, "name": "Alice"}],
+            "posts": [{"id": 10, "title": "Hi", "user_id": 1}],
+        }
+
+        result = (
+            stream([chunk])
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("posts")
+            .each()
+            .map_to(
+                table=StreamPost,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(StreamUser, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+        assert result.stats["stream_posts"].inserted == 1
+        session.close()
+
+
+class TestLoadEagerStreaming:
+    def test_eager_parent_shared_across_chunks(self):
+        eager = {"tags": [{"id": 1, "name": "t1"}, {"id": 2, "name": "t2"}]}
+        chunks = [
+            {"items": [{"id": 1, "name": "i0", "tag_id": 1}]},
+            {"items": [{"id": 2, "name": "i1", "tag_id": 2}]},
+        ]
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            stream(chunks, eager_roots=eager)
+            .goto("tags")
+            .each()
+            .map_to(
+                table=StreamTag,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load_eager(StreamTag)
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=StreamItem,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(StreamTag, by={"tag_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+        assert session.query(StreamTag).count() == 2
+        assert session.query(StreamItem).count() == 2
+        session.close()
+
+
+class TestMultiRootChunk:
+    def test_indexed_multi_root_chunk_merge(self):
+        users_root = {"users": [{"id": "u1", "name": "Alice"}]}
+        profiles_root = {"profiles": [{"user_id": "u1", "email": "alice@example.com"}]}
+        source = CallableChunkSource(
+            lambda: iter([Chunk(roots=(users_root, profiles_root), sequential=False)])
+        )
+
+        result = (
+            stream(source)
+            .goto("users")
+            .each()
+            .map_to(
+                table="users",
+                join_on=["id"],
+                fields=[
+                    Field("id", get("id")),
+                    Field("name", get("name")),
+                ],
+            )
+            .goto_root(1)
+            .goto("profiles")
+            .each()
+            .map_to(
+                table="users",
+                join_on=["id"],
+                fields=[
+                    Field("email", get("email")),
+                    TempField("id", get("user_id")),
+                ],
+            )
+            .load(sessionmaker(bind=create_engine("sqlite:///:memory:"))())
+            .run()
+        )
+
+        assert result.stats["users"].mapped == 1
+        assert result.stats["users"].inserted == 1
+
+
+class TestFlushStrategySeam:
+    def test_strategy_receives_bind_context(self):
+        seen: list[FlushContext] = []
+
+        class RecordingStrategy(KeyCompleteFlushStrategy):
+            def flush(self, ctx: FlushContext) -> None:
+                seen.append(ctx)
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            stream([{"users": [{"id": 1, "name": "A"}]}], flush_strategy=RecordingStrategy())
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+
+        assert len(seen) >= 1
+        ctx = seen[0]
+        assert "stream_users" in ctx.scope_tables
+        assert "stream_users" in ctx.bind_context
+        session.close()
+
+
+class TestStreamingValidation:
+    def test_rejects_composite_by_at_build_time(self):
+        builder = (
+            stream([{}])
+            .goto("children")
+            .each()
+            .map_to(table="children", fields=[TempField("a", get("a")), TempField("b", get("b"))])
+            .link_to("parents", by={"a": "x", "b": "y"})
+            .load(MagicMock())
+        )
+        with pytest.raises(ValueError, match="single-field by"):
+            builder.run()
+
+    def test_one_record_per_chunk_source(self):
+        source = OneRecordPerChunkSource([{"x": 1}, {"x": 2}])
+        chunks = list(source.chunks())
+        assert len(chunks) == 2
+        assert chunks[0].roots == ({"x": 1},)
+        assert chunks[0].sequential is True

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
 from etielle import Field, TempField, etl, get, stream
 from etielle.chunking import (
@@ -35,6 +36,9 @@ class StreamPost(Base):
     id = Column(Integer, primary_key=True)
     title = Column(String)
     user_id = Column(Integer, ForeignKey("stream_users.id"))
+    # Attribute name matches link_to's inferred parent name (parent table
+    # "stream_users" -> "stream_user"); binding populates user_id on flush.
+    stream_user = relationship("StreamUser")
 
 
 class StreamTag(Base):
@@ -48,6 +52,7 @@ class StreamItem(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     tag_id = Column(Integer, ForeignKey("stream_tags.id"))
+    stream_tag = relationship("StreamTag")
 
 
 class StreamSale(Base):
@@ -524,6 +529,228 @@ class TestFlushStrategySeam:
         session.commit()
 
         assert session.query(StreamUser).count() == 1
+        session.close()
+
+
+class _CapturingStrategy(KeyCompleteFlushStrategy):
+    """Records the ORM instances passed to each flush for state inspection."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.captured: list = []
+
+    def flush(self, ctx: FlushContext) -> None:
+        for result in ctx.local_results.values():
+            for instance in result.instances.values():
+                if not isinstance(instance, dict):
+                    self.captured.append(instance)
+        super().flush(ctx)
+
+
+class TestSessionEviction:
+    def test_flushed_instances_evicted_by_default(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        strategy = _CapturingStrategy()
+        chunks = [
+            {"users": [{"id": 1, "name": "A"}]},
+            {"users": [{"id": 2, "name": "B"}]},
+            {"users": [{"id": 3, "name": "C"}]},
+        ]
+
+        (
+            stream(chunks, flush_strategy=strategy)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[Field("name", get("name")), TempField("id", get("id"))],
+            )
+            .load(session)
+            .run()
+        )
+
+        # Every flushed instance is detached from the session after its chunk.
+        assert len(strategy.captured) == 3
+        assert all(sa_inspect(obj).detached for obj in strategy.captured)
+        session.commit()
+        assert session.query(StreamUser).count() == 3
+        session.close()
+
+    def test_eviction_can_be_disabled(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        strategy = _CapturingStrategy(evict_flushed=False)
+        chunks = [
+            {"users": [{"id": 1, "name": "A"}]},
+            {"users": [{"id": 2, "name": "B"}]},
+            {"users": [{"id": 3, "name": "C"}]},
+        ]
+
+        (
+            stream(chunks, flush_strategy=strategy)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[Field("name", get("name")), TempField("id", get("id"))],
+            )
+            .load(session)
+            .run()
+        )
+
+        # With eviction disabled, flushed instances stay attached (persistent).
+        assert len(strategy.captured) == 3
+        assert all(not sa_inspect(obj).detached for obj in strategy.captured)
+        session.commit()
+        assert session.query(StreamUser).count() == 3
+        session.close()
+
+    def test_eager_parents_survive_eviction(self):
+        eager = {"tags": [{"id": 1, "name": "t1"}, {"id": 2, "name": "t2"}]}
+        chunks = [
+            {"items": [{"id": 1, "name": "i0", "tag_id": 1}]},
+            {"items": [{"id": 2, "name": "i1", "tag_id": 1}]},
+            {"items": [{"id": 3, "name": "i2", "tag_id": 2}]},
+        ]
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            stream(chunks, eager_roots=eager)
+            .goto("tags")
+            .each()
+            .map_to(
+                table=StreamTag,
+                fields=[Field("name", get("name")), TempField("id", get("id"))],
+            )
+            .load_eager(StreamTag)
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=StreamItem,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(StreamTag, by={"tag_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        # All three items bound to a resident eager tag across chunks.
+        assert session.query(StreamItem).count() == 3
+        assert session.query(StreamTag).count() == 2
+        items = session.query(StreamItem).order_by(StreamItem.id).all()
+        assert items[0].tag_id == 1
+        assert items[2].tag_id == 2
+        session.close()
+
+    def test_evicted_data_is_correct_with_relationships(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        chunks = [
+            {
+                "users": [{"id": 1, "name": "Alice"}],
+                "posts": [{"id": 10, "title": "Hi", "user_id": 1}],
+            },
+            {
+                "users": [{"id": 2, "name": "Bob"}],
+                "posts": [{"id": 11, "title": "Yo", "user_id": 2}],
+            },
+        ]
+
+        (
+            stream(chunks)
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[Field("name", get("name")), TempField("id", get("id"))],
+            )
+            .goto_root()
+            .goto("posts")
+            .each()
+            .map_to(
+                table=StreamPost,
+                fields=[
+                    Field("title", get("title")),
+                    TempField("id", get("id")),
+                    TempField("user_id", get("user_id")),
+                ],
+            )
+            .link_to(StreamUser, by={"user_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        posts = session.query(StreamPost).order_by(StreamPost.id).all()
+        assert [p.user_id for p in posts] == [1, 2]
+        session.close()
+
+    def test_eager_scope_is_not_evictable(self):
+        """Eager flushes are marked non-evictable; streaming components are."""
+        seen: list[tuple[frozenset, bool]] = []
+
+        class EvictableRecorder(KeyCompleteFlushStrategy):
+            def flush(self, ctx: FlushContext) -> None:
+                seen.append((frozenset(ctx.scope_tables), ctx.evictable))
+                super().flush(ctx)
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            stream(
+                [{"items": [{"id": 1, "name": "i0", "tag_id": 1}]}],
+                eager_roots={"tags": [{"id": 1, "name": "t1"}]},
+                flush_strategy=EvictableRecorder(),
+            )
+            .goto("tags")
+            .each()
+            .map_to(
+                table=StreamTag,
+                fields=[Field("name", get("name")), TempField("id", get("id"))],
+            )
+            .load_eager(StreamTag)
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=StreamItem,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(StreamTag, by={"tag_id": "id"})
+            .load(session)
+            .run()
+        )
+
+        evictable_by_scope = {scope: ev for scope, ev in seen}
+        assert evictable_by_scope[frozenset({"stream_tags"})] is False
+        assert evictable_by_scope[frozenset({"stream_items"})] is True
         session.close()
 
 

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -484,3 +484,54 @@ class TestStreamingValidation:
         assert len(chunks) == 2
         assert chunks[0].roots == ({"x": 1},)
         assert chunks[0].sequential is True
+
+    def test_sequential_source_rejects_multi_root_pipeline_statically(self):
+        builder = (
+            stream([{"users": []}, {"profiles": []}])
+            .goto("users")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[Field("id", get("id"))])
+            .goto_root(1)
+            .goto("profiles")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[TempField("id", get("uid"))])
+            .load(MagicMock())
+        )
+        with pytest.raises(ValueError, match="requires multi-root chunks"):
+            builder.run()
+
+    def test_sequential_chunk_with_multi_root_emissions_raises_at_runtime(self):
+        source = CallableChunkSource(
+            lambda: iter([Chunk(roots=({"users": []},), sequential=True)])
+        )
+        builder = (
+            stream(source)
+            .goto("users")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[Field("id", get("id"))])
+            .goto_root(1)
+            .goto("profiles")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[TempField("id", get("uid"))])
+            .load(MagicMock())
+        )
+        with pytest.raises(ValueError, match="support only a single root"):
+            builder.run()
+
+    def test_multi_root_chunk_missing_root_raises(self):
+        source = CallableChunkSource(
+            lambda: iter([Chunk(roots=({"users": [{"id": "u1"}]},), sequential=False)])
+        )
+        builder = (
+            stream(source)
+            .goto("users")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[Field("id", get("id"))])
+            .goto_root(1)
+            .goto("profiles")
+            .each()
+            .map_to(table="users", join_on=["id"], fields=[TempField("id", get("uid"))])
+            .load(sessionmaker(bind=create_engine("sqlite:///:memory:"))())
+        )
+        with pytest.raises(ValueError, match="references goto_root\\(1\\)"):
+            builder.run()

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -182,10 +182,15 @@ class TestResidentParity:
 
 class TestAutoKeySafety:
     def test_auto_keys_do_not_collide_in_chunk(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
         records = [
-            {"items": [{"name": "a"}]},
-            {"items": [{"name": "b"}]},
-            {"items": [{"name": "c"}]},
+            {"users": [{"name": "a"}]},
+            {"users": [{"name": "b"}]},
+            {"users": [{"name": "c"}]},
         ]
 
         result = (
@@ -194,15 +199,18 @@ class TestAutoKeySafety:
                     lambda: iter([Chunk(roots=tuple(records), sequential=True)])
                 )
             )
-            .goto("items")
+            .goto("users")
             .each()
-            .map_to(table="items", fields=[Field("name", get("name"))])
-            .load(sessionmaker(bind=create_engine("sqlite:///:memory:"))())
+            .map_to(table=StreamUser, fields=[Field("name", get("name"))])
+            .load(session)
             .run()
         )
+        session.commit()
 
-        assert result.stats["items"].mapped == 3
-        assert result.stats["items"].inserted == 3
+        assert result.stats["stream_users"].mapped == 3
+        assert result.stats["stream_users"].inserted == 3
+        assert session.query(StreamUser).count() == 3
+        session.close()
 
 
 class TestStatsAggregation:
@@ -393,8 +401,13 @@ class TestLoadEagerStreaming:
 
 class TestMultiRootChunk:
     def test_indexed_multi_root_chunk_merge(self):
-        users_root = {"users": [{"id": "u1", "name": "Alice"}]}
-        profiles_root = {"profiles": [{"user_id": "u1", "email": "alice@example.com"}]}
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        users_root = {"users": [{"id": 1, "name": "Alice"}]}
+        profiles_root = {"profiles": [{"user_id": 1, "name_suffix": " Smith"}]}
         source = CallableChunkSource(
             lambda: iter([Chunk(roots=(users_root, profiles_root), sequential=False)])
         )
@@ -404,7 +417,7 @@ class TestMultiRootChunk:
             .goto("users")
             .each()
             .map_to(
-                table="users",
+                table=StreamUser,
                 join_on=["id"],
                 fields=[
                     Field("id", get("id")),
@@ -415,19 +428,23 @@ class TestMultiRootChunk:
             .goto("profiles")
             .each()
             .map_to(
-                table="users",
+                table=StreamUser,
                 join_on=["id"],
                 fields=[
-                    Field("email", get("email")),
+                    Field("name", get("name_suffix")),
                     TempField("id", get("user_id")),
                 ],
             )
-            .load(sessionmaker(bind=create_engine("sqlite:///:memory:"))())
+            .load(session)
             .run()
         )
+        session.commit()
 
-        assert result.stats["users"].mapped == 1
-        assert result.stats["users"].inserted == 1
+        rows = session.query(StreamUser).all()
+        assert len(rows) == 1
+        assert result.stats["stream_users"].mapped == 1
+        assert result.stats["stream_users"].inserted == 1
+        session.close()
 
 
 class TestFlushStrategySeam:

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -479,6 +479,51 @@ class TestFlushStrategySeam:
         ctx = seen[0]
         assert "stream_users" in ctx.scope_tables
         assert "stream_users" in ctx.bind_context
+        assert ctx.session is session
+        assert ctx.is_supabase is False
+        session.close()
+
+    def test_custom_strategy_persists_via_public_fields(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        class PublicFieldStrategy:
+            """Persists using only public FlushContext fields, no builder internals."""
+
+            def flush(self, ctx: FlushContext) -> None:
+                from etielle.utils import topological_sort
+
+                for table in topological_sort(ctx.dep_graph, ctx.scope_tables):
+                    result = ctx.local_results.get(table)
+                    if result is None:
+                        continue
+                    for instance in result.instances.values():
+                        if not isinstance(instance, dict):
+                            ctx.session.add(instance)
+                ctx.session.flush()
+
+        (
+            stream(
+                [{"users": [{"id": 1, "name": "A"}]}],
+                flush_strategy=PublicFieldStrategy(),
+            )
+            .goto("users")
+            .each()
+            .map_to(
+                table=StreamUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(StreamUser).count() == 1
         session.close()
 
 

--- a/tests/test_issue_75.py
+++ b/tests/test_issue_75.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
-from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
 from etielle import Field, TempField, etl, get, stream
@@ -532,87 +531,8 @@ class TestFlushStrategySeam:
         session.close()
 
 
-class _CapturingStrategy(KeyCompleteFlushStrategy):
-    """Records the ORM instances passed to each flush for state inspection."""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.captured: list = []
-
-    def flush(self, ctx: FlushContext) -> None:
-        for result in ctx.local_results.values():
-            for instance in result.instances.values():
-                if not isinstance(instance, dict):
-                    self.captured.append(instance)
-        super().flush(ctx)
-
-
-class TestSessionEviction:
-    def test_flushed_instances_evicted_by_default(self):
-        engine = create_engine("sqlite:///:memory:")
-        Base.metadata.create_all(engine)
-        Session = sessionmaker(bind=engine)
-        session = Session()
-
-        strategy = _CapturingStrategy()
-        chunks = [
-            {"users": [{"id": 1, "name": "A"}]},
-            {"users": [{"id": 2, "name": "B"}]},
-            {"users": [{"id": 3, "name": "C"}]},
-        ]
-
-        (
-            stream(chunks, flush_strategy=strategy)
-            .goto("users")
-            .each()
-            .map_to(
-                table=StreamUser,
-                fields=[Field("name", get("name")), TempField("id", get("id"))],
-            )
-            .load(session)
-            .run()
-        )
-
-        # Every flushed instance is detached from the session after its chunk.
-        assert len(strategy.captured) == 3
-        assert all(sa_inspect(obj).detached for obj in strategy.captured)
-        session.commit()
-        assert session.query(StreamUser).count() == 3
-        session.close()
-
-    def test_eviction_can_be_disabled(self):
-        engine = create_engine("sqlite:///:memory:")
-        Base.metadata.create_all(engine)
-        Session = sessionmaker(bind=engine)
-        session = Session()
-
-        strategy = _CapturingStrategy(evict_flushed=False)
-        chunks = [
-            {"users": [{"id": 1, "name": "A"}]},
-            {"users": [{"id": 2, "name": "B"}]},
-            {"users": [{"id": 3, "name": "C"}]},
-        ]
-
-        (
-            stream(chunks, flush_strategy=strategy)
-            .goto("users")
-            .each()
-            .map_to(
-                table=StreamUser,
-                fields=[Field("name", get("name")), TempField("id", get("id"))],
-            )
-            .load(session)
-            .run()
-        )
-
-        # With eviction disabled, flushed instances stay attached (persistent).
-        assert len(strategy.captured) == 3
-        assert all(not sa_inspect(obj).detached for obj in strategy.captured)
-        session.commit()
-        assert session.query(StreamUser).count() == 3
-        session.close()
-
-    def test_eager_parents_survive_eviction(self):
+class TestCrossChunkRelationships:
+    def test_eager_parent_bound_across_chunks(self):
         eager = {"tags": [{"id": 1, "name": "t1"}, {"id": 2, "name": "t2"}]}
         chunks = [
             {"items": [{"id": 1, "name": "i0", "tag_id": 1}]},
@@ -651,7 +571,8 @@ class TestSessionEviction:
         )
         session.commit()
 
-        # All three items bound to a resident eager tag across chunks.
+        # All three items, mapped in separate chunks, bind to the resident eager
+        # tags and persist the correct foreign key.
         assert session.query(StreamItem).count() == 3
         assert session.query(StreamTag).count() == 2
         items = session.query(StreamItem).order_by(StreamItem.id).all()
@@ -659,7 +580,7 @@ class TestSessionEviction:
         assert items[2].tag_id == 2
         session.close()
 
-    def test_evicted_data_is_correct_with_relationships(self):
+    def test_within_chunk_relationship_fk_persisted(self):
         engine = create_engine("sqlite:///:memory:")
         Base.metadata.create_all(engine)
         Session = sessionmaker(bind=engine)
@@ -703,54 +624,6 @@ class TestSessionEviction:
 
         posts = session.query(StreamPost).order_by(StreamPost.id).all()
         assert [p.user_id for p in posts] == [1, 2]
-        session.close()
-
-    def test_eager_scope_is_not_evictable(self):
-        """Eager flushes are marked non-evictable; streaming components are."""
-        seen: list[tuple[frozenset, bool]] = []
-
-        class EvictableRecorder(KeyCompleteFlushStrategy):
-            def flush(self, ctx: FlushContext) -> None:
-                seen.append((frozenset(ctx.scope_tables), ctx.evictable))
-                super().flush(ctx)
-
-        engine = create_engine("sqlite:///:memory:")
-        Base.metadata.create_all(engine)
-        Session = sessionmaker(bind=engine)
-        session = Session()
-
-        (
-            stream(
-                [{"items": [{"id": 1, "name": "i0", "tag_id": 1}]}],
-                eager_roots={"tags": [{"id": 1, "name": "t1"}]},
-                flush_strategy=EvictableRecorder(),
-            )
-            .goto("tags")
-            .each()
-            .map_to(
-                table=StreamTag,
-                fields=[Field("name", get("name")), TempField("id", get("id"))],
-            )
-            .load_eager(StreamTag)
-            .goto_root()
-            .goto("items")
-            .each()
-            .map_to(
-                table=StreamItem,
-                fields=[
-                    Field("name", get("name")),
-                    TempField("id", get("id")),
-                    TempField("tag_id", get("tag_id")),
-                ],
-            )
-            .link_to(StreamTag, by={"tag_id": "id"})
-            .load(session)
-            .run()
-        )
-
-        evictable_by_scope = {scope: ev for scope, ev in seen}
-        assert evictable_by_scope[frozenset({"stream_tags"})] is False
-        assert evictable_by_scope[frozenset({"stream_items"})] is True
         session.close()
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements sub-issue B of #9: opt-in streaming/chunked execution with the key-complete + relationship-complete contract.

- Adds `stream()` entry point (alias `etl.stream`) for chunked pipelines
- Introduces `ChunkSource` / `FlushStrategy` seams with default `KeyCompleteFlushStrategy`
- Refactors `PipelineBuilder.run()` into reusable eager + component phases shared with resident mode
- Validates relationship-completeness at chunk boundaries (`RelationshipIncompleteError`)
- Preserves auto-key uniqueness across sequential roots in a chunk via `MappingRuntimeState`
- Accumulates per-table stats additively across chunks

## API

```python
from etielle import stream, Field, TempField, get

result = (
    stream(record_iter)          # one root per chunk
    .goto("users").each()
    .map_to(table=User, fields=[...])
    .load(session)
    .run()
)
session.commit()
```

Shared dimension tables: `stream(chunks, eager_roots=tags_data).load_eager(Tag)...`

## Contract

- Streaming requires `load()` (no full in-memory collection mode)
- Chunks must be key-complete and relationship-complete
- Cross-chunk scattered merge is unsupported (documented)
- Traversal-based `build_index()` and composite `link_to(by=...)` rejected in streaming

## Tests

New `tests/test_issue_75.py` covers:
- Resident vs chunked parity
- Auto-key safety across sequential roots in one chunk
- Cumulative stats
- Within-chunk merge policies
- Relationship completeness errors
- `load_eager()` across chunks
- Multi-root indexed chunks
- FlushStrategy seam

Closes #75

## Follow-ups

- #76: H1 group-by and pre-segmented `ChunkSource` helpers
- #77: deferred upsert/buffered strategies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94b2c71-d243-4dd0-97fe-a53b6a4171c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94b2c71-d243-4dd0-97fe-a53b6a4171c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

