### PR TITLE
feat: mandatory chunking helpers (streaming group-by + pre-segmented passthrough)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `KeyCompleteFlushStrategy` as the default flush strategy for streaming
 - Relationship-completeness validation for incomplete chunks
 - Additive per-table stats across chunk boundaries
+- `GroupByChunkSource` single-pass streaming group-by chunking helper (one-chunk memory footprint over grouped/sorted input)
+- `PreSegmentedChunkSource` passthrough for caller-supplied iterables of chunks
 
 ## v4.0.0 (2026-06-25)
 

--- a/docs/database-loading.qmd
+++ b/docs/database-loading.qmd
@@ -292,7 +292,40 @@ stream(chunks, eager_roots=tags_snapshot)
     ...
 ```
 
-For arbitrarily grouped input, see the chunking helpers in issue #76 (`ChunkSource` group-by and pre-segmented passthrough).
+### Chunking helpers
+
+Producing correct chunks is part of the streaming contract, so etielle ships two `ChunkSource` helpers rather than leaving boundary-finding to the caller.
+
+**`GroupByChunkSource` (single-pass group-by).** Given a `key` function, it reads the input once, accumulates consecutive records that share a key, and emits a chunk when the key changes. Peak memory is one chunk.
+
+```python
+from etielle import stream, GroupByChunkSource, Field, TempField, get
+
+# Each record is a parent subtree; group by the owning order id.
+source = GroupByChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
+
+stream(source)
+    .goto("orders").each()
+    .map_to(table=Order, fields=[Field("customer", get("customer")), TempField("id", get("id"))])
+    .goto_root()
+    .goto("items").each()
+    .map_to(table=LineItem, fields=[...])
+    .link_to(Order, by={"order_id": "id"})
+    .load(session)
+    .run()
+```
+
+- **Grouped-input requirement.** Grouping is *consecutive only*, so the input must already be grouped (or sorted) by `key`—the natural shape for paginated APIs and "one parent subtree at a time" feeds. If two records share a key but are separated by a record with a different key, they land in different chunks; that still satisfies key-completeness, but the runtime relationship-completeness check will raise if a chunk is then missing relationship endpoints. For unsorted input, sort by `key` first (the robust unsorted-input partitioner, H2, is deferred).
+- **Pick a relationship-complete key.** Choose a key that is a *complete component root*—coarse enough that everything reachable through a relationship from a record sharing the key also shares it (e.g. the owning entity id), not merely a fine merge key. Grouping guarantees key-completeness for the chosen key; the runtime validation catches a key that is too fine.
+
+**`PreSegmentedChunkSource` (passthrough).** If you already have an iterable of `Chunk` objects, hand it over directly—it yields them in order without buffering.
+
+```python
+from etielle import stream, PreSegmentedChunkSource, Chunk
+
+chunks = [Chunk(roots=(subtree,), sequential=True) for subtree in producer]
+stream(PreSegmentedChunkSource(chunks)).goto(...)...
+```
 
 ### Why streaming bounds memory
 

--- a/etielle/__init__.py
+++ b/etielle/__init__.py
@@ -157,6 +157,8 @@ from .chunking import (
     KeyCompleteFlushStrategy,
     OneRecordPerChunkSource,
     CallableChunkSource,
+    GroupByChunkSource,
+    PreSegmentedChunkSource,
 )
 
 __all__ += [
@@ -174,5 +176,7 @@ __all__ += [
     "KeyCompleteFlushStrategy",
     "OneRecordPerChunkSource",
     "CallableChunkSource",
+    "GroupByChunkSource",
+    "PreSegmentedChunkSource",
     "MappingRuntimeState",
 ]

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
+from itertools import groupby
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -63,6 +64,78 @@ class CallableChunkSource:
 
     def chunks(self) -> Iterator[Chunk]:
         yield from self._factory()
+
+
+class GroupByChunkSource:
+    """Group consecutive records that share a key into one chunk each.
+
+    This is the single-pass, streaming group-by chunker. It reads the input
+    once, accumulates consecutive records that map to the same ``key``, and
+    emits a chunk whenever the key changes. Peak memory is one chunk: only the
+    records for the current key are held at a time.
+
+    Each emitted chunk is ``sequential`` -- every record in the group is mapped
+    against pipeline root index 0 with shared auto-key counters, so a group of
+    related records merges into one component (the repeated single-root shape).
+
+    Grouped-input requirement:
+        Correctness depends on the input *already being grouped (or sorted) by
+        ``key``*, which is the common shape for paginated APIs and "one parent
+        subtree at a time" feeds. Because grouping is consecutive only, records
+        that share a key but are separated by records with a different key land
+        in *separate* chunks. With a relationship key that is fine for
+        key-completeness but breaks relationship-completeness; the runtime
+        relationship-completeness check raises if a chunk is missing endpoints.
+        For unsorted input, sort by ``key`` first, or wait for the robust
+        unsorted-input partitioner (H2, tracked under sub-issue D).
+
+    Choosing a relationship-complete key:
+        Pick a key that is a *complete component root* -- coarse enough that
+        every record reachable through a relationship from one record sharing
+        the key also shares it (e.g. the owning entity id), not merely a fine
+        merge key. Grouping guarantees key-completeness for whatever key you
+        choose; the runtime validation catches a key that is too fine.
+
+    Args:
+        records: An iterable (or single-use iterator) of JSON roots. Consumed
+            exactly once.
+        key: Function mapping a record to its grouping key. Adjacent records
+            with equal keys are batched into the same chunk.
+    """
+
+    def __init__(
+        self,
+        records: Iterator[Any] | Iterable[Any],
+        key: Callable[[Any], Any],
+    ) -> None:
+        self._records = records
+        self._key = key
+
+    def chunks(self) -> Iterator[Chunk]:
+        for _, group in groupby(self._records, key=self._key):
+            yield Chunk(roots=tuple(group), sequential=True)
+
+
+class PreSegmentedChunkSource:
+    """Pass an already-segmented iterable of chunks through unchanged.
+
+    Use this when the caller has already partitioned input into key-complete,
+    relationship-complete ``Chunk`` objects (e.g. a producer that knows its own
+    boundaries). The chunks are yielded in order without buffering, so peak
+    memory is whatever the upstream iterable holds at a time.
+
+    A re-iterable input (e.g. a list) can be streamed more than once; a
+    single-use iterator is consumed on the first pass.
+
+    Args:
+        chunks: An iterable (or single-use iterator) of ``Chunk`` objects.
+    """
+
+    def __init__(self, chunks: Iterator[Chunk] | Iterable[Chunk]) -> None:
+        self._chunks = chunks
+
+    def chunks(self) -> Iterator[Chunk]:
+        yield from self._chunks
 
 
 @dataclass

--- a/tests/test_issue_76.py
+++ b/tests/test_issue_76.py
@@ -1,0 +1,230 @@
+"""Tests for issue #76: mandatory chunking helpers.
+
+Covers the single-pass streaming group-by ``GroupByChunkSource`` and the
+pre-segmented passthrough ``PreSegmentedChunkSource``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, get, stream
+from etielle.chunking import (
+    Chunk,
+    ChunkSource,
+    GroupByChunkSource,
+    OneRecordPerChunkSource,
+    PreSegmentedChunkSource,
+)
+
+
+Base = declarative_base()
+
+
+class Order(Base):
+    __tablename__ = "orders_76"
+    id = Column(Integer, primary_key=True)
+    customer = Column(String)
+
+
+class LineItem(Base):
+    __tablename__ = "line_items_76"
+    id = Column(Integer, primary_key=True)
+    sku = Column(String)
+    order_id = Column(Integer, ForeignKey("orders_76.id"))
+    # link_to infers the relationship attribute from the parent table name via
+    # ``rstrip("s")``; "orders_76" has no trailing 's', so the attr is "orders_76".
+    orders_76 = relationship("Order")
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+class TestGroupByChunkSource:
+    def test_is_chunk_source(self):
+        source = GroupByChunkSource([], key=lambda r: r)
+        assert isinstance(source, ChunkSource)
+
+    def test_groups_consecutive_records_by_key(self):
+        records = [
+            {"oid": 1, "v": "a"},
+            {"oid": 1, "v": "b"},
+            {"oid": 2, "v": "c"},
+            {"oid": 3, "v": "d"},
+            {"oid": 3, "v": "e"},
+        ]
+        source = GroupByChunkSource(records, key=lambda r: r["oid"])
+        chunks = list(source.chunks())
+
+        assert [c.roots for c in chunks] == [
+            ({"oid": 1, "v": "a"}, {"oid": 1, "v": "b"}),
+            ({"oid": 2, "v": "c"},),
+            ({"oid": 3, "v": "d"}, {"oid": 3, "v": "e"}),
+        ]
+        assert all(c.sequential for c in chunks)
+
+    def test_empty_input_yields_no_chunks(self):
+        assert list(GroupByChunkSource([], key=lambda r: r).chunks()) == []
+
+    def test_non_consecutive_same_key_splits_into_separate_chunks(self):
+        # Documents the grouped-input requirement: unsorted input is grouped
+        # only by consecutive runs, so key 1 lands in two separate chunks.
+        records = [{"k": 1}, {"k": 2}, {"k": 1}]
+        chunks = list(GroupByChunkSource(records, key=lambda r: r["k"]).chunks())
+        assert [c.roots for c in chunks] == [
+            ({"k": 1},),
+            ({"k": 2},),
+            ({"k": 1},),
+        ]
+
+    def test_single_pass_lazy_consumption(self):
+        consumed: list[int] = []
+
+        def gen():
+            for i in [1, 1, 2]:
+                consumed.append(i)
+                yield {"k": i}
+
+        chunk_iter = GroupByChunkSource(gen(), key=lambda r: r["k"]).chunks()
+
+        # Pulling the first chunk only consumes up to the first key boundary
+        # (the lookahead record that changes the key), not the whole input.
+        first = next(chunk_iter)
+        assert first.roots == ({"k": 1}, {"k": 1})
+        assert consumed == [1, 1, 2]
+
+        second = next(chunk_iter)
+        assert second.roots == ({"k": 2},)
+
+    def test_streaming_groups_relationship_complete_chunks(self):
+        session = _session()
+        # Each record is a parent subtree: an order plus its line items. The
+        # group key is the owning order id -> a complete component root.
+        records = [
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [
+                    {"id": 10, "sku": "x", "order_id": 1},
+                    {"id": 11, "sku": "y", "order_id": 1},
+                ],
+            },
+            {
+                "orders": [{"id": 2, "customer": "Bob"}],
+                "items": [{"id": 20, "sku": "z", "order_id": 2}],
+            },
+        ]
+        source = GroupByChunkSource(records, key=lambda r: r["orders"][0]["id"])
+
+        (
+            stream(source)
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                fields=[Field("customer", get("customer")), TempField("id", get("id"))],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Order).count() == 2
+        assert session.query(LineItem).count() == 3
+        items = session.query(LineItem).order_by(LineItem.id).all()
+        assert [i.order_id for i in items] == [1, 1, 2]
+        session.close()
+
+
+class TestPreSegmentedChunkSource:
+    def test_is_chunk_source(self):
+        assert isinstance(PreSegmentedChunkSource([]), ChunkSource)
+
+    def test_passes_chunks_through_unchanged(self):
+        chunks = [
+            Chunk(roots=({"a": 1},), sequential=True),
+            Chunk(roots=({"b": 2}, {"c": 3}), sequential=False),
+        ]
+        out = list(PreSegmentedChunkSource(chunks).chunks())
+        assert out == chunks
+
+    def test_accepts_single_use_iterator(self):
+        gen = (Chunk(roots=({"k": i},), sequential=True) for i in range(3))
+        out = list(PreSegmentedChunkSource(gen).chunks())
+        assert [c.roots for c in out] == [({"k": 0},), ({"k": 1},), ({"k": 2},)]
+
+    def test_streaming_with_presegmented_source(self):
+        session = _session()
+        chunks = [
+            Chunk(
+                roots=(
+                    {
+                        "orders": [{"id": 1, "customer": "Alice"}],
+                        "items": [{"id": 10, "sku": "x", "order_id": 1}],
+                    },
+                ),
+                sequential=True,
+            ),
+            Chunk(
+                roots=(
+                    {
+                        "orders": [{"id": 2, "customer": "Bob"}],
+                        "items": [{"id": 20, "sku": "z", "order_id": 2}],
+                    },
+                ),
+                sequential=True,
+            ),
+        ]
+
+        (
+            stream(PreSegmentedChunkSource(chunks))
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                fields=[Field("customer", get("customer")), TempField("id", get("id"))],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Order).count() == 2
+        assert session.query(LineItem).count() == 2
+        session.close()
+
+
+def test_helpers_exported_from_package():
+    import etielle
+
+    assert etielle.GroupByChunkSource is GroupByChunkSource
+    assert etielle.PreSegmentedChunkSource is PreSegmentedChunkSource
+    # Sanity: the pre-existing one-record helper is still the default wrapper.
+    assert isinstance(OneRecordPerChunkSource([]), ChunkSource)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#76](https://github.com/Promptly-Technologies-LLC/etielle/issues/76): the mandatory chunking helpers that produce key-complete chunks so callers don't have to find chunk boundaries themselves.

Both build on the existing `ChunkSource` interface (sub-issue B, already merged) and live in `etielle/chunking.py`.

### `GroupByChunkSource` — single-pass streaming group-by (H1)
Given a `key` function, it reads the input once, accumulates consecutive records sharing a key, and emits a `Chunk` (with `sequential=True`) when the key changes. Implemented with `itertools.groupby`, so peak memory is one chunk: only the current key's records are materialized at a time.

Correct **only when the input is already grouped/sorted by `key`** — the common paginated-API / "one parent subtree at a time" shape. The docstring and docs spell out this requirement, how to pick a relationship-complete key (a complete component root, not a fine merge key), and point to H2 (deferred, sub-issue D) for robust unsorted-input partitioning.

### `PreSegmentedChunkSource` — passthrough
If the caller already has an iterable of `Chunk` objects, this yields them in order unchanged without buffering.

## Changes
- `etielle/chunking.py`: add `GroupByChunkSource` and `PreSegmentedChunkSource`.
- `etielle/__init__.py`: export both helpers.
- `docs/database-loading.qmd`: replace the issue-#76 placeholder with a "Chunking helpers" section covering the grouped-input requirement, relationship-complete key choice, and the H2 pointer.
- `CHANGELOG.md`: note both helpers under the unreleased v4.1.0 features.
- `tests/test_issue_76.py`: new tests.

## Acceptance criteria
- [x] Grouped input yields correct key-complete chunks with a one-chunk memory footprint (verified via lazy single-pass consumption test).
- [x] Pre-segmented iterables pass through unchanged.
- [x] Docs cover the grouped-input requirement, relationship-complete key selection, and the H2 pointer.

## Testing
- `uv run pytest` — 340 passed, 4 skipped.
- `uv run mypy etielle/chunking.py` — no issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3c99308-ccea-4c79-8a8e-e5d4fb3019ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3c99308-ccea-4c79-8a8e-e5d4fb3019ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

