### PR TITLE
feat: additional ChunkSource/FlushStrategy implementations (issue #77)

### DIFF
--- a/etielle/__init__.py
+++ b/etielle/__init__.py
@@ -155,10 +155,13 @@ from .chunking import (
     FlushContext,
     FlushStrategy,
     KeyCompleteFlushStrategy,
+    UpsertFlushStrategy,
+    BufferedKeyFlushStrategy,
     OneRecordPerChunkSource,
     CallableChunkSource,
     GroupByChunkSource,
     PreSegmentedChunkSource,
+    ExternalPartitionChunkSource,
 )
 
 __all__ += [
@@ -174,9 +177,12 @@ __all__ += [
     "FlushContext",
     "FlushStrategy",
     "KeyCompleteFlushStrategy",
+    "UpsertFlushStrategy",
+    "BufferedKeyFlushStrategy",
     "OneRecordPerChunkSource",
     "CallableChunkSource",
     "GroupByChunkSource",
     "PreSegmentedChunkSource",
+    "ExternalPartitionChunkSource",
     "MappingRuntimeState",
 ]

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import tempfile
+from collections import OrderedDict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from etielle.fluent import PipelineBuilder, TableStats
@@ -86,8 +89,9 @@ class GroupByChunkSource:
         in *separate* chunks. With a relationship key that is fine for
         key-completeness but breaks relationship-completeness; the runtime
         relationship-completeness check raises if a chunk is missing endpoints.
-        For unsorted input, sort by ``key`` first, or wait for the robust
-        unsorted-input partitioner (H2, tracked under sub-issue D).
+        For unsorted input, sort by ``key`` first or use
+        ``ExternalPartitionChunkSource``, the disk-backed partitioner that
+        handles arbitrarily-ordered input.
 
     Choosing a relationship-complete key:
         Pick a key that is a *complete component root* -- coarse enough that
@@ -136,6 +140,90 @@ class PreSegmentedChunkSource:
 
     def chunks(self) -> Iterator[Chunk]:
         yield from self._chunks
+
+
+class ExternalPartitionChunkSource:
+    """Partition arbitrarily-ordered input into key-complete chunks via disk.
+
+    This is the two-pass, disk-backed partitioner (H2): pass one serializes
+    every record to a temporary spill file and builds an in-memory
+    key -> offsets index; pass two emits one chunk per distinct key by reading
+    that key's records back from disk. Unlike ``GroupByChunkSource`` it does
+    not require the input to be grouped or sorted -- records that share a key
+    are collected into the same chunk no matter how far apart they arrive.
+
+    Trade-offs:
+        Peak record memory is one chunk (the current partition), but the full
+        dataset is written to temporary storage, and the offset index holds a
+        few machine words per record for the duration of the stream. Pass two
+        performs random reads, so a fast local temp filesystem is preferable.
+
+    Serialization:
+        Records are serialized with ``dumps`` (default ``json.dumps``) and
+        deserialized with ``loads`` (default ``json.loads``), so chunks yield
+        *reconstructed copies* of the input records. Non-JSON-serializable
+        records need custom ``dumps``/``loads`` callables.
+
+    Emission order:
+        Chunks are emitted in first-appearance order of their keys. Each chunk
+        is ``sequential`` -- every record in the partition is mapped against
+        pipeline root index 0 with shared auto-key counters, matching
+        ``GroupByChunkSource``.
+
+    Choosing a relationship-complete key:
+        As with ``GroupByChunkSource``, pick a key that is a complete
+        component root; partitioning guarantees key-completeness for the
+        chosen key, and the runtime relationship-completeness check catches a
+        key that is too fine.
+
+    Args:
+        records: An iterable (or single-use iterator) of JSON roots. Consumed
+            exactly once per ``chunks()`` iteration.
+        key: Function mapping a record to its partition key. Must return a
+            hashable value.
+        dir: Optional directory for the temporary spill file (defaults to the
+            platform temp directory). The file is deleted when iteration
+            finishes or the iterator is closed.
+        dumps: Serializer from record to ``str`` (default ``json.dumps``).
+        loads: Deserializer from ``str`` to record (default ``json.loads``).
+    """
+
+    def __init__(
+        self,
+        records: Iterator[Any] | Iterable[Any],
+        key: Callable[[Any], Any],
+        *,
+        dir: str | None = None,
+        dumps: Callable[[Any], str] | None = None,
+        loads: Callable[[str], Any] | None = None,
+    ) -> None:
+        self._records = records
+        self._key = key
+        self._dir = dir
+        self._dumps = dumps if dumps is not None else json.dumps
+        self._loads = loads if loads is not None else json.loads
+
+    def chunks(self) -> Iterator[Chunk]:
+        spill = tempfile.TemporaryFile(
+            mode="w+b", dir=self._dir, prefix="etielle-partition-"
+        )
+        try:
+            index: dict[Any, list[tuple[int, int]]] = {}
+            offset = 0
+            for record in self._records:
+                data = self._dumps(record).encode("utf-8")
+                spill.write(data)
+                index.setdefault(self._key(record), []).append((offset, len(data)))
+                offset += len(data)
+
+            for spans in index.values():
+                roots = []
+                for span_offset, span_length in spans:
+                    spill.seek(span_offset)
+                    roots.append(self._loads(spill.read(span_length).decode("utf-8")))
+                yield Chunk(roots=tuple(roots), sequential=True)
+        finally:
+            spill.close()
 
 
 @dataclass
@@ -219,3 +307,320 @@ class KeyCompleteFlushStrategy:
                 ctx.stats,
                 ctx.on_event,
             )
+
+
+def _is_auto_key(key: tuple[Any, ...]) -> bool:
+    """Return True for engine-generated auto keys (no ``join_on`` on the table)."""
+    return len(key) == 1 and isinstance(key[0], str) and key[0].startswith("__auto_")
+
+
+def _parent_attr_name(parent_table: str) -> str:
+    """Infer the relationship attribute name from a parent table name."""
+    return parent_table.rstrip("s") if parent_table.endswith("s") else parent_table
+
+
+def _copy_instance_state(target: Any, incoming: Any) -> None:
+    """Copy non-None scalar attribute values from ``incoming`` onto ``target``.
+
+    Collection-valued attributes (lists/sets, e.g. backlink relationship
+    collections) and private/engine attributes are left untouched, so merging
+    a late-arriving row cannot detach previously bound children.
+    """
+    for attr_name, value in vars(incoming).items():
+        if attr_name.startswith("_"):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, (list, set)):
+            continue
+        setattr(target, attr_name, value)
+
+
+class UpsertFlushStrategy:
+    """Streaming strategy with database-level conflict handling (SQLAlchemy).
+
+    Where the default ``KeyCompleteFlushStrategy`` uses plain ``session.add()``
+    (a duplicate row aborts the chunk's transaction with ``IntegrityError``),
+    this strategy resolves conflicts against rows that are *already stored*:
+
+    - ``on_conflict="update"`` (default): each instance is persisted with
+      ``session.merge()``. If a row with the same primary key exists, its
+      columns are overwritten with the incoming values (last write wins);
+      otherwise the row is inserted. Suited to idempotent re-runs.
+    - ``on_conflict="skip"``: each instance is inserted inside a per-row
+      ``SAVEPOINT``; a row that raises ``IntegrityError`` (duplicate primary
+      key or unique constraint, including a concurrent-insert race) is rolled
+      back and skipped while the rest of the chunk proceeds. Suited to
+      on-conflict-skip deduplication of streaming ingest.
+
+    Documented limitations:
+
+    - **SQLAlchemy only.** For Supabase, pass ``load(upsert=True,
+      upsert_on=...)`` with the default strategy; the Supabase adapter
+      performs native upserts.
+    - **Not a cross-chunk merge substitute.** Merge policies
+      (``AddPolicy`` etc.) run only within a chunk's mapping pass; across
+      re-runs, ``update`` mode overwrites whole rows (including ``None``
+      values) rather than merging fields.
+    - **``update`` mode detects conflicts by primary key.** Instances without
+      primary key values are inserted as new rows, and each merge issues a
+      per-row SELECT when the row is not already in the session's identity
+      map. A concurrent insert between that SELECT and the INSERT can still
+      raise ``IntegrityError``; use ``skip`` mode where races must be
+      tolerated.
+    - **``skip`` mode swallows every ``IntegrityError``,** not only duplicate
+      keys (e.g. a NOT NULL violation also skips the row), and pays a per-row
+      SAVEPOINT + flush round trip. A child bound to a skipped parent is
+      itself skipped, because the cascaded parent insert reproduces the
+      conflict inside the child's SAVEPOINT. Skipped rows are counted in
+      ``mapped`` stats but in neither ``inserted`` nor ``failed``.
+    - **Plain-dict rows** (string table targets) are not persisted, matching
+      the default strategy.
+    """
+
+    def __init__(self, on_conflict: Literal["update", "skip"] = "update") -> None:
+        if on_conflict not in ("update", "skip"):
+            raise ValueError(
+                f"on_conflict must be 'update' or 'skip', got {on_conflict!r}"
+            )
+        self._on_conflict = on_conflict
+
+    def flush(self, ctx: FlushContext) -> None:
+        if ctx.session is None:
+            return
+        if ctx.is_supabase:
+            raise ValueError(
+                "UpsertFlushStrategy supports SQLAlchemy sessions only. For "
+                "Supabase, use load(upsert=True, upsert_on=...) with the default "
+                "flush strategy; the Supabase adapter performs native upserts."
+            )
+        from etielle.telemetry import FlushStarted, _emit
+        from etielle.utils import topological_sort
+
+        for table_name in topological_sort(ctx.dep_graph, ctx.scope_tables):
+            result = ctx.local_results.get(table_name)
+            if result is None:
+                continue
+            _emit(
+                FlushStarted(table=table_name, count=len(result.instances)),
+                ctx.on_event,
+            )
+            if self._on_conflict == "update":
+                self._flush_update(ctx, table_name, result)
+            else:
+                self._flush_skip(ctx, table_name, result)
+
+    def _flush_update(self, ctx: FlushContext, table_name: str, result: Any) -> None:
+        from etielle.telemetry import FlushCompleted, FlushFailed, _emit
+
+        merged_count = 0
+        try:
+            for _key, instance in result.instances.items():
+                if isinstance(instance, dict):
+                    continue
+                ctx.session.merge(instance)
+                merged_count += 1
+            ctx.session.flush()
+        except Exception as e:
+            _emit(
+                FlushFailed(
+                    table=table_name, error=str(e), affected_count=merged_count
+                ),
+                ctx.on_event,
+            )
+            if table_name in ctx.stats:
+                ctx.builder._accumulate_stats(
+                    ctx.stats, table_name, failed=merged_count
+                )
+            raise
+        _emit(
+            FlushCompleted(
+                table=table_name,
+                inserted=merged_count,
+                failed=0,
+                batch_num=1,
+                batch_total=1,
+                upsert=True,
+            ),
+            ctx.on_event,
+        )
+        if table_name in ctx.stats:
+            ctx.builder._accumulate_stats(
+                ctx.stats, table_name, inserted=merged_count
+            )
+
+    def _flush_skip(self, ctx: FlushContext, table_name: str, result: Any) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        from etielle.telemetry import FlushCompleted, FlushFailed, _emit
+
+        inserted = 0
+        try:
+            for _key, instance in result.instances.items():
+                if isinstance(instance, dict):
+                    continue
+                try:
+                    with ctx.session.begin_nested():
+                        ctx.session.add(instance)
+                        ctx.session.flush()
+                    inserted += 1
+                except IntegrityError:
+                    continue
+        except Exception as e:
+            _emit(
+                FlushFailed(table=table_name, error=str(e), affected_count=inserted),
+                ctx.on_event,
+            )
+            if table_name in ctx.stats:
+                ctx.builder._accumulate_stats(ctx.stats, table_name, failed=inserted)
+            raise
+        _emit(
+            FlushCompleted(
+                table=table_name,
+                inserted=inserted,
+                failed=0,
+                batch_num=1,
+                batch_total=1,
+                upsert=True,
+            ),
+            ctx.on_event,
+        )
+        if table_name in ctx.stats:
+            ctx.builder._accumulate_stats(ctx.stats, table_name, inserted=inserted)
+
+
+class BufferedKeyFlushStrategy:
+    """Streaming strategy that merges late-arriving rows for recently seen keys.
+
+    Keeps a bounded LRU cache of the last ``max_keys`` flushed
+    ``(table, join key)`` -> instance entries. When a later chunk maps a row
+    whose key is still cached, the row is *not* inserted again; instead its
+    non-None scalar attribute values are copied onto the already-persisted
+    instance, which SQLAlchemy turns into an UPDATE at the next flush. Rows
+    with new keys are inserted normally and recorded in the cache.
+
+    Children mapped alongside a re-appearing parent are relinked to the
+    originally persisted parent instance, so no duplicate parent row is
+    inserted through relationship cascades.
+
+    Documented limitations:
+
+    - **Correctness is a heuristic bounded by ``max_keys``.** The cache
+      assumes key reappearance distance is bounded: once a key is evicted, a
+      reappearing row is inserted as a new row (or raises ``IntegrityError``
+      under a unique constraint). This is not a guarantee -- size the cache
+      for the worst-case reappearance gap or fall back to
+      ``ExternalPartitionChunkSource`` for exact grouping.
+    - **Requires natural keys.** Only tables with ``join_on`` participate;
+      auto-keyed rows are always inserted because auto keys restart per chunk
+      and would collide spuriously.
+    - **Merge is last-non-None-write-wins per scalar attribute.** Merge
+      policies (``AddPolicy`` etc.) run only within a chunk's mapping pass;
+      collection-valued attributes (e.g. ``backlink()`` lists) are not merged
+      across chunks.
+    - **Relationship completeness is still validated per chunk.** A child
+      whose parent appears only in an earlier chunk is rejected before the
+      strategy runs; the cache merges repeated *rows*, it does not relax the
+      chunk contract for relationships.
+    - **Stateful across the run.** Use a fresh instance per pipeline run;
+      merged (deduplicated) rows are counted in ``mapped`` stats but not in
+      ``inserted``.
+    - **SQLAlchemy only**; plain-dict rows are not persisted, matching the
+      default strategy.
+
+    Args:
+        max_keys: Maximum number of ``(table, key)`` entries to retain.
+            Bounds strategy memory to at most ``max_keys`` live instances.
+    """
+
+    def __init__(self, max_keys: int = 10_000) -> None:
+        if max_keys < 1:
+            raise ValueError(f"max_keys must be >= 1, got {max_keys}")
+        self._max_keys = max_keys
+        self._cache: OrderedDict[tuple[str, tuple[Any, ...]], Any] = OrderedDict()
+
+    def flush(self, ctx: FlushContext) -> None:
+        if ctx.session is None:
+            return
+        if ctx.is_supabase:
+            raise ValueError(
+                "BufferedKeyFlushStrategy supports SQLAlchemy sessions only."
+            )
+        from etielle.telemetry import (
+            FlushCompleted,
+            FlushFailed,
+            FlushStarted,
+            _emit,
+        )
+        from etielle.utils import topological_sort
+
+        parent_attrs: dict[str, list[str]] = {}
+        for rel in ctx.link_to_rels:
+            parent_attrs.setdefault(rel["child_table"], []).append(
+                _parent_attr_name(rel["parent_table"])
+            )
+
+        # Maps id(duplicate chunk-local instance) -> cached persisted instance,
+        # so children bound to a duplicate parent are relinked before insert.
+        replacements: dict[int, Any] = {}
+
+        for table_name in topological_sort(ctx.dep_graph, ctx.scope_tables):
+            result = ctx.local_results.get(table_name)
+            if result is None:
+                continue
+            _emit(
+                FlushStarted(table=table_name, count=len(result.instances)),
+                ctx.on_event,
+            )
+            inserted = 0
+            try:
+                for key, instance in result.instances.items():
+                    if isinstance(instance, dict):
+                        continue
+                    for attr in parent_attrs.get(table_name, ()):
+                        bound = getattr(instance, attr, None)
+                        if bound is not None and id(bound) in replacements:
+                            setattr(instance, attr, replacements[id(bound)])
+                    if _is_auto_key(key):
+                        ctx.session.add(instance)
+                        inserted += 1
+                        continue
+                    cache_key = (table_name, key)
+                    cached = self._cache.get(cache_key)
+                    if cached is not None and cached is not instance:
+                        _copy_instance_state(cached, instance)
+                        replacements[id(instance)] = cached
+                        self._cache.move_to_end(cache_key)
+                    else:
+                        ctx.session.add(instance)
+                        inserted += 1
+                        self._cache[cache_key] = instance
+                        self._cache.move_to_end(cache_key)
+                        while len(self._cache) > self._max_keys:
+                            self._cache.popitem(last=False)
+                ctx.session.flush()
+            except Exception as e:
+                _emit(
+                    FlushFailed(
+                        table=table_name, error=str(e), affected_count=inserted
+                    ),
+                    ctx.on_event,
+                )
+                if table_name in ctx.stats:
+                    ctx.builder._accumulate_stats(
+                        ctx.stats, table_name, failed=inserted
+                    )
+                raise
+            _emit(
+                FlushCompleted(
+                    table=table_name,
+                    inserted=inserted,
+                    failed=0,
+                    batch_num=1,
+                    batch_total=1,
+                    upsert=False,
+                ),
+                ctx.on_event,
+            )
+            if table_name in ctx.stats:
+                ctx.builder._accumulate_stats(ctx.stats, table_name, inserted=inserted)

--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -145,7 +145,7 @@ class PreSegmentedChunkSource:
 class ExternalPartitionChunkSource:
     """Partition arbitrarily-ordered input into key-complete chunks via disk.
 
-    This is the two-pass, disk-backed partitioner (H2): pass one serializes
+    This is the two-pass, disk-backed partitioner: pass one serializes
     every record to a temporary spill file and builds an in-memory
     key -> offsets index; pass two emits one chunk per distinct key by reading
     that key's records back from disk. Unlike ``GroupByChunkSource`` it does

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1265,14 +1265,26 @@ class PipelineBuilder:
 
     def _merge_mapping_results(self, existing: Any, incoming: Any) -> None:
         """Merge incoming MappingResult into existing in place."""
+        # Maps id(discarded incoming instance) -> retained instance, so index
+        # entries can be redirected and relationship binding never resolves to
+        # a discarded duplicate.
+        replaced: dict[int, Any] = {}
         for key, row in incoming.instances.items():
             if key in existing.instances:
-                if hasattr(existing.instances[key], "update"):
-                    existing.instances[key].update(row)
-                elif hasattr(existing.instances[key], "__dict__"):
+                retained = existing.instances[key]
+                if retained is not row:
+                    replaced[id(row)] = retained
+                if hasattr(retained, "update"):
+                    retained.update(row)
+                elif hasattr(retained, "__dict__"):
                     source = row.__dict__ if hasattr(row, "__dict__") else row
                     for k, v in source.items():
-                        setattr(existing.instances[key], k, v)
+                        # Private attributes (e.g. SQLAlchemy's
+                        # _sa_instance_state) belong to the incoming instance
+                        # and must not be transplanted onto the existing one.
+                        if k.startswith("_"):
+                            continue
+                        setattr(retained, k, v)
             else:
                 existing.instances[key] = row
         for key, msgs in incoming.update_errors.items():
@@ -1280,7 +1292,9 @@ class PipelineBuilder:
         for key, msgs in incoming.finalize_errors.items():
             existing.finalize_errors.setdefault(key, []).extend(msgs)
         for field_name, index in incoming.indices.items():
-            existing.indices.setdefault(field_name, {}).update(index)
+            target = existing.indices.setdefault(field_name, {})
+            for value, obj in index.items():
+                target[value] = replaced.get(id(obj), obj)
         existing.lookup_values.update(incoming.lookup_values)
 
     def _map_roots(

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -79,6 +79,7 @@ user_guide:
   - section: "Advanced Topics"
     contents:
       - database-loading.qmd
+      - scaling-and-memory.qmd
       - custom-transforms.qmd
       - error-handling.qmd
 
@@ -96,15 +97,18 @@ reference:
     contents:
       - AddPolicy  # 1 method(s)
       - AppendPolicy  # 1 method(s)
+      - BufferedKeyFlushStrategy  # 1 method(s)
       - CallableChunkSource  # 1 method(s)
       - name: ConstructorBuilder
         members: false  # 8 methods listed below
       - ExtendPolicy  # 1 method(s)
+      - ExternalPartitionChunkSource  # 1 method(s)
       - FirstNonNullPolicy  # 1 method(s)
       - GroupByChunkSource  # 1 method(s)
       - name: InstanceBuilder
         members: false  # 9 methods listed below
       - KeyCompleteFlushStrategy  # 1 method(s)
+      - UpsertFlushStrategy  # 1 method(s)
       - MaxPolicy  # 1 method(s)
       - MergePolicy  # 1 method(s)
       - MinPolicy  # 1 method(s)

--- a/tests/test_issue_77.py
+++ b/tests/test_issue_77.py
@@ -1,0 +1,508 @@
+"""Tests for issue #77: additional ``ChunkSource``/``FlushStrategy`` implementations.
+
+Covers the disk-backed ``ExternalPartitionChunkSource`` (H2), the
+``UpsertFlushStrategy`` (on-conflict update/skip), and the
+``BufferedKeyFlushStrategy`` (bounded cross-chunk key merge).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, get, stream
+from etielle.chunking import (
+    BufferedKeyFlushStrategy,
+    ChunkSource,
+    ExternalPartitionChunkSource,
+    FlushContext,
+    UpsertFlushStrategy,
+)
+
+
+Base = declarative_base()
+
+
+class Order(Base):
+    __tablename__ = "orders_77"
+    id = Column(Integer, primary_key=True)
+    customer = Column(String)
+
+
+class LineItem(Base):
+    __tablename__ = "line_items_77"
+    id = Column(Integer, primary_key=True)
+    sku = Column(String)
+    order_id = Column(Integer, ForeignKey("orders_77.id"))
+    # link_to infers the relationship attribute from the parent table name via
+    # ``rstrip("s")``; "orders_77" has no trailing 's', so the attr is "orders_77".
+    orders_77 = relationship("Order")
+
+
+class User(Base):
+    __tablename__ = "users_77"
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    name = Column(String)
+    phone = Column(String)
+
+
+class Event(Base):
+    __tablename__ = "events_77"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    ext_id = Column(String)
+    payload = Column(String)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _supabase_ctx(strategy_session: object) -> FlushContext:
+    return FlushContext(
+        scope_tables={"t"},
+        bind_context={},
+        local_results={},
+        dep_graph={},
+        link_to_rels=[],
+        backlink_rels=[],
+        stats={},
+        on_event=None,
+        session=strategy_session,
+        is_supabase=True,
+        builder=None,  # type: ignore[arg-type]
+    )
+
+
+class TestExternalPartitionChunkSource:
+    def test_is_chunk_source(self):
+        source = ExternalPartitionChunkSource([], key=lambda r: r)
+        assert isinstance(source, ChunkSource)
+
+    def test_partitions_unsorted_input_by_key(self):
+        records = [
+            {"k": 1, "v": "a"},
+            {"k": 2, "v": "b"},
+            {"k": 1, "v": "c"},
+            {"k": 3, "v": "d"},
+            {"k": 2, "v": "e"},
+        ]
+        source = ExternalPartitionChunkSource(records, key=lambda r: r["k"])
+        chunks = list(source.chunks())
+
+        # One chunk per distinct key, in first-appearance order.
+        assert [c.roots for c in chunks] == [
+            ({"k": 1, "v": "a"}, {"k": 1, "v": "c"}),
+            ({"k": 2, "v": "b"}, {"k": 2, "v": "e"}),
+            ({"k": 3, "v": "d"},),
+        ]
+        assert all(c.sequential for c in chunks)
+
+    def test_empty_input_yields_no_chunks(self):
+        assert list(ExternalPartitionChunkSource([], key=lambda r: r).chunks()) == []
+
+    def test_records_are_reconstructed_copies(self):
+        record = {"k": 1, "nested": {"a": [1, 2]}}
+        chunks = list(
+            ExternalPartitionChunkSource([record], key=lambda r: r["k"]).chunks()
+        )
+        assert chunks[0].roots[0] == record
+        assert chunks[0].roots[0] is not record
+
+    def test_custom_dumps_loads(self):
+        records = ["x:1", "x:2", "y:3"]
+        source = ExternalPartitionChunkSource(
+            records,
+            key=lambda r: r.split(":")[0],
+            dumps=lambda r: r,
+            loads=lambda s: s,
+        )
+        chunks = list(source.chunks())
+        assert [c.roots for c in chunks] == [("x:1", "x:2"), ("y:3",)]
+
+    def test_spill_file_cleaned_up(self, tmp_path):
+        records = [{"k": i % 2, "i": i} for i in range(10)]
+        source = ExternalPartitionChunkSource(
+            records, key=lambda r: r["k"], dir=str(tmp_path)
+        )
+        list(source.chunks())
+        assert list(tmp_path.iterdir()) == []
+
+    def test_spill_file_cleaned_up_on_early_close(self, tmp_path):
+        records = [{"k": i, "i": i} for i in range(5)]
+        source = ExternalPartitionChunkSource(
+            records, key=lambda r: r["k"], dir=str(tmp_path)
+        )
+        chunk_iter = source.chunks()
+        next(chunk_iter)
+        chunk_iter.close()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_streaming_partitions_relationship_complete_chunks(self):
+        session = _session()
+        # Records for the same order are interleaved with other orders: the
+        # consecutive-only GroupByChunkSource would split them, but the
+        # external partitioner reunites them into one chunk per order.
+        records = [
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [{"id": 10, "sku": "x", "order_id": 1}],
+            },
+            {
+                "orders": [{"id": 2, "customer": "Bob"}],
+                "items": [{"id": 20, "sku": "z", "order_id": 2}],
+            },
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [{"id": 11, "sku": "y", "order_id": 1}],
+            },
+        ]
+        source = ExternalPartitionChunkSource(
+            records, key=lambda r: r["orders"][0]["id"]
+        )
+
+        (
+            stream(source)
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                join_on=["id"],
+                fields=[Field("id", get("id")), Field("customer", get("customer"))],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Order).count() == 2
+        assert session.query(LineItem).count() == 3
+        items = session.query(LineItem).order_by(LineItem.sku).all()
+        assert [i.order_id for i in items] == [1, 1, 2]
+        session.close()
+
+
+class TestUpsertFlushStrategy:
+    def _run_users(self, session, records, strategy):
+        return (
+            stream(records, flush_strategy=strategy)
+            .goto("users")
+            .each()
+            .map_to(
+                table=User,
+                join_on=["id"],
+                fields=[
+                    Field("id", get("id")),
+                    Field("email", get("email")),
+                    Field("name", get("name")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+
+    def test_invalid_on_conflict_rejected(self):
+        with pytest.raises(ValueError, match="on_conflict"):
+            UpsertFlushStrategy(on_conflict="explode")  # type: ignore[arg-type]
+
+    def test_supabase_session_rejected(self):
+        with pytest.raises(ValueError, match="SQLAlchemy"):
+            UpsertFlushStrategy().flush(_supabase_ctx(object()))
+
+    def test_update_mode_inserts_new_rows(self):
+        session = _session()
+        result = self._run_users(
+            session,
+            [{"users": [{"id": 1, "email": "a@x.com", "name": "Alice"}]}],
+            UpsertFlushStrategy(),
+        )
+        session.commit()
+        assert session.query(User).count() == 1
+        assert result.stats["users_77"].inserted == 1
+        session.close()
+
+    def test_update_mode_overwrites_existing_row(self):
+        session = _session()
+        self._run_users(
+            session,
+            [{"users": [{"id": 1, "email": "a@x.com", "name": "Alice"}]}],
+            UpsertFlushStrategy(),
+        )
+        session.commit()
+
+        # Re-run with a changed name: same primary key, so the row is updated
+        # in place instead of raising IntegrityError.
+        self._run_users(
+            session,
+            [{"users": [{"id": 1, "email": "a@x.com", "name": "Alicia"}]}],
+            UpsertFlushStrategy(),
+        )
+        session.commit()
+
+        rows = session.query(User).all()
+        assert len(rows) == 1
+        assert rows[0].name == "Alicia"
+        session.close()
+
+    def test_update_mode_emits_upsert_telemetry(self):
+        from etielle.telemetry import FlushCompleted
+
+        session = _session()
+        events = []
+        (
+            stream(
+                [{"users": [{"id": 1, "email": "a@x.com", "name": "A"}]}],
+                flush_strategy=UpsertFlushStrategy(),
+            )
+            .goto("users")
+            .each()
+            .map_to(
+                table=User,
+                join_on=["id"],
+                fields=[
+                    Field("id", get("id")),
+                    Field("email", get("email")),
+                    Field("name", get("name")),
+                ],
+            )
+            .load(session)
+            .run(on_event=events.append)
+        )
+        completed = [e for e in events if isinstance(e, FlushCompleted)]
+        assert completed and all(e.upsert for e in completed)
+        session.close()
+
+    def test_skip_mode_skips_conflicting_rows_and_keeps_rest(self):
+        session = _session()
+        session.add(User(id=99, email="taken@x.com", name="Stored"))
+        session.commit()
+
+        result = self._run_users(
+            session,
+            [
+                # Conflicts on the unique email despite the fresh primary key.
+                {"users": [{"id": 1, "email": "taken@x.com", "name": "Dup"}]},
+                {"users": [{"id": 2, "email": "new@x.com", "name": "New"}]},
+            ],
+            UpsertFlushStrategy(on_conflict="skip"),
+        )
+        session.commit()
+
+        emails = {u.email: u.name for u in session.query(User).all()}
+        assert emails == {"taken@x.com": "Stored", "new@x.com": "New"}
+        assert result.stats["users_77"].mapped == 2
+        assert result.stats["users_77"].inserted == 1
+        session.close()
+
+    def test_skip_mode_cascades_to_children_of_skipped_parent(self):
+        session = _session()
+        session.add(Order(id=1, customer="Stored"))
+        session.commit()
+
+        (
+            stream(
+                [
+                    {
+                        "orders": [{"id": 1, "customer": "Dup"}],
+                        "items": [{"id": 10, "sku": "x", "order_id": 1}],
+                    }
+                ],
+                flush_strategy=UpsertFlushStrategy(on_conflict="skip"),
+            )
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                join_on=["id"],
+                fields=[Field("id", get("id")), Field("customer", get("customer"))],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        # The child is bound to the conflicting in-memory parent, so its
+        # SAVEPOINT reproduces the conflict via cascade and the child is
+        # skipped along with the duplicate parent.
+        assert session.query(Order).count() == 1
+        assert session.query(Order).one().customer == "Stored"
+        assert session.query(LineItem).count() == 0
+        session.close()
+
+
+class TestBufferedKeyFlushStrategy:
+    def test_invalid_max_keys_rejected(self):
+        with pytest.raises(ValueError, match="max_keys"):
+            BufferedKeyFlushStrategy(max_keys=0)
+
+    def test_supabase_session_rejected(self):
+        with pytest.raises(ValueError, match="SQLAlchemy"):
+            BufferedKeyFlushStrategy().flush(_supabase_ctx(object()))
+
+    def test_late_arriving_row_merges_into_cached_key(self):
+        session = _session()
+        # The second chunk re-visits user 1 with a phone number but no name;
+        # non-None values merge onto the already-flushed instance.
+        chunks = [
+            {"users": [{"id": 1, "email": "a@x.com", "name": "Alice"}]},
+            {"users": [{"id": 1, "phone": "555-0100"}]},
+        ]
+        result = (
+            stream(chunks, flush_strategy=BufferedKeyFlushStrategy())
+            .goto("users")
+            .each()
+            .map_to(
+                table=User,
+                join_on=["id"],
+                fields=[
+                    Field("id", get("id")),
+                    Field("email", get("email")),
+                    Field("name", get("name")),
+                    Field("phone", get("phone")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        rows = session.query(User).all()
+        assert len(rows) == 1
+        assert rows[0].name == "Alice"
+        assert rows[0].phone == "555-0100"
+        assert result.stats["users_77"].mapped == 2
+        assert result.stats["users_77"].inserted == 1
+        session.close()
+
+    def test_evicted_key_inserts_new_row(self):
+        session = _session()
+        chunks = [
+            {"events": [{"ext_id": "a", "payload": "1"}]},
+            {"events": [{"ext_id": "b", "payload": "2"}]},
+            # "a" was evicted by "b" (max_keys=1), so it inserts a new row
+            # instead of merging: correctness is bounded by cache size.
+            {"events": [{"ext_id": "a", "payload": "3"}]},
+        ]
+        (
+            stream(chunks, flush_strategy=BufferedKeyFlushStrategy(max_keys=1))
+            .goto("events")
+            .each()
+            .map_to(
+                table=Event,
+                join_on=["ext_id"],
+                fields=[
+                    Field("ext_id", get("ext_id")),
+                    Field("payload", get("payload")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Event).count() == 3
+        session.close()
+
+    def test_auto_keyed_rows_always_insert(self):
+        session = _session()
+        chunks = [
+            {"events": [{"ext_id": "a", "payload": "1"}]},
+            {"events": [{"ext_id": "a", "payload": "1"}]},
+        ]
+        (
+            stream(chunks, flush_strategy=BufferedKeyFlushStrategy())
+            .goto("events")
+            .each()
+            .map_to(
+                # No join_on: auto keys restart per chunk, so they never merge.
+                table=Event,
+                fields=[
+                    Field("ext_id", get("ext_id")),
+                    Field("payload", get("payload")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Event).count() == 2
+        session.close()
+
+    def test_reappearing_parent_relinks_children_without_duplicate_insert(self):
+        session = _session()
+        chunks = [
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [{"id": 10, "sku": "x", "order_id": 1}],
+            },
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [{"id": 11, "sku": "y", "order_id": 1}],
+            },
+        ]
+        (
+            stream(chunks, flush_strategy=BufferedKeyFlushStrategy())
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                join_on=["id"],
+                fields=[Field("id", get("id")), Field("customer", get("customer"))],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Order).count() == 1
+        items = session.query(LineItem).order_by(LineItem.sku).all()
+        assert [i.order_id for i in items] == [1, 1]
+        session.close()
+
+
+def test_new_types_exported_from_package():
+    import etielle
+
+    assert etielle.ExternalPartitionChunkSource is ExternalPartitionChunkSource
+    assert etielle.UpsertFlushStrategy is UpsertFlushStrategy
+    assert etielle.BufferedKeyFlushStrategy is BufferedKeyFlushStrategy

--- a/user-guide/database-loading.qmd
+++ b/user-guide/database-loading.qmd
@@ -294,7 +294,7 @@ stream(chunks, eager_roots=tags_snapshot)
 
 ### Chunking helpers
 
-Producing correct chunks is part of the streaming contract, so etielle ships two `ChunkSource` helpers rather than leaving boundary-finding to the caller.
+Producing correct chunks is part of the streaming contract, so etielle ships `ChunkSource` helpers rather than leaving boundary-finding to the caller.
 
 **`GroupByChunkSource` (single-pass group-by).** Given a `key` function, it reads the input once, accumulates consecutive records that share a key, and emits a chunk when the key changes. Peak memory is one chunk.
 
@@ -315,8 +315,22 @@ stream(source)
     .run()
 ```
 
-- **Grouped-input requirement.** Grouping is *consecutive only*, so the input must already be grouped (or sorted) by `key`—the natural shape for paginated APIs and "one parent subtree at a time" feeds. If two records share a key but are separated by a record with a different key, they land in different chunks; that still satisfies key-completeness, but the runtime relationship-completeness check will raise if a chunk is then missing relationship endpoints. For unsorted input, sort by `key` first (the robust unsorted-input partitioner, H2, is deferred).
+- **Grouped-input requirement.** Grouping is *consecutive only*, so the input must already be grouped (or sorted) by `key`—the natural shape for paginated APIs and "one parent subtree at a time" feeds. If two records share a key but are separated by a record with a different key, they land in different chunks; that still satisfies key-completeness, but the runtime relationship-completeness check will raise if a chunk is then missing relationship endpoints. For unsorted input, sort by `key` first or use `ExternalPartitionChunkSource`.
 - **Pick a relationship-complete key.** Choose a key that is a *complete component root*—coarse enough that everything reachable through a relationship from a record sharing the key also shares it (e.g. the owning entity id), not merely a fine merge key. Grouping guarantees key-completeness for the chosen key; the runtime validation catches a key that is too fine.
+
+**`ExternalPartitionChunkSource` (disk-backed partitioner for unsorted input).** The two-pass complement to `GroupByChunkSource`: pass one serializes every record to a temporary spill file and builds a key→offsets index; pass two emits one chunk per distinct key (in first-appearance order) by reading that key's records back from disk. Records sharing a key are reunited no matter how far apart they arrive, so no pre-sorting is needed.
+
+```python
+from etielle import stream, ExternalPartitionChunkSource
+
+# Records for the same order may be interleaved with other orders.
+source = ExternalPartitionChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
+stream(source).goto(...)...
+```
+
+- **Trade-offs.** Peak record memory is one chunk (the current partition), but the whole dataset is written to temp storage and the offset index holds a few machine words per record for the duration of the stream. Pass two performs random reads, so prefer a fast local temp filesystem (override the location with `dir=`).
+- **Serialization.** Records round-trip through `dumps`/`loads` (default `json.dumps`/`json.loads`), so chunks yield reconstructed copies; pass custom callables for non-JSON records. The spill file is deleted when iteration finishes or the chunk iterator is closed.
+- The same relationship-complete-key guidance as `GroupByChunkSource` applies.
 
 **`PreSegmentedChunkSource` (passthrough).** If you already have an iterable of `Chunk` objects, hand it over directly—it yields them in order without buffering.
 
@@ -333,9 +347,40 @@ Streaming keeps peak memory flat regardless of dataset size: etielle maps a chun
 
 On the SQLAlchemy side this needs no special handling: the session's identity map references *persistent* (flushed, clean) instances weakly, so once etielle drops its per-chunk references, CPython's garbage collector reclaims them. Transaction control still belongs to the caller—the `INSERT`s accumulate in the open transaction until you commit or roll back. For a very long stream, commit at a cadence that suits your durability needs; a single end-of-stream commit keeps everything in one transaction.
 
-### Extending flush behavior
+### Flush strategies
 
-The chunk loop is strategy-agnostic: it calls `FlushStrategy.flush(ctx)` at each component boundary. A custom strategy receives a `FlushContext` exposing the scoped tables, mapped results, dependency graph, relationships, stats sink, telemetry callback, and the `session`/`is_supabase` target. Custom strategies (e.g. upsert or buffered variants from issue #77) implement persistence using those public fields plus `etielle.utils.topological_sort`; the built-in `KeyCompleteFlushStrategy` delegates to etielle's standard insert/bind logic.
+The chunk loop is strategy-agnostic: it calls `FlushStrategy.flush(ctx)` at each component boundary, and `stream(..., flush_strategy=...)` selects which strategy runs. Three strategies ship with etielle.
+
+**`KeyCompleteFlushStrategy` (default).** Plain insert/flush with no cross-chunk state, delegating to etielle's standard insert/bind logic. A row whose key conflicts with an already-stored row raises `IntegrityError` and aborts the chunk's transaction.
+
+**`UpsertFlushStrategy` (database-level conflict handling, SQLAlchemy only).** Resolves conflicts against rows that are already stored, for idempotent re-runs and streaming ingest that may re-encounter stored records:
+
+```python
+from etielle import stream, UpsertFlushStrategy
+
+stream(records, flush_strategy=UpsertFlushStrategy())                     # ON CONFLICT-style update
+stream(records, flush_strategy=UpsertFlushStrategy(on_conflict="skip"))   # skip conflicting rows
+```
+
+- `on_conflict="update"` (default) persists each instance with `session.merge()`: an existing row with the same primary key is overwritten (last write wins); otherwise the row is inserted. Conflict detection is by primary key, so instances need their key values set, and each merge can issue a per-row SELECT. A concurrent insert between that SELECT and the INSERT can still raise `IntegrityError`.
+- `on_conflict="skip"` inserts each instance inside a per-row `SAVEPOINT` and skips any row that raises `IntegrityError`—duplicate primary keys, unique-constraint conflicts (including concurrent-insert races), but also any other integrity violation. A child bound to a skipped parent is itself skipped, because the cascaded parent insert reproduces the conflict inside the child's `SAVEPOINT`. Skipped rows appear in `mapped` stats but in neither `inserted` nor `failed`.
+- Not a cross-chunk-merge substitute: merge policies (`AddPolicy` etc.) run only within a chunk's mapping pass, and `update` mode overwrites whole rows rather than merging fields.
+- For Supabase, use `load(upsert=True, upsert_on=...)` with the default strategy instead; the Supabase adapter performs native upserts.
+
+**`BufferedKeyFlushStrategy` (bounded cross-chunk key merge, SQLAlchemy only).** Keeps an LRU cache of the last `max_keys` flushed `(table, join key)` entries. When a later chunk maps a row whose key is still cached, its non-None scalar values are copied onto the already-persisted instance (an UPDATE at the next flush) instead of inserting a duplicate, and children mapped alongside the re-appearing row are relinked to the persisted instance:
+
+```python
+from etielle import stream, BufferedKeyFlushStrategy
+
+stream(records, flush_strategy=BufferedKeyFlushStrategy(max_keys=50_000))
+```
+
+- **Correctness is a heuristic bounded by cache size**, not a guarantee: once a key is evicted, a reappearing row inserts a new row (or raises `IntegrityError` under a unique constraint). Size `max_keys` for the worst-case reappearance gap, or use `ExternalPartitionChunkSource` for exact grouping.
+- Only tables with `join_on` participate; auto-keyed rows always insert because auto keys restart per chunk. Merge is last-non-None-write-wins per scalar attribute; collection attributes (e.g. `backlink()` lists) are not merged across chunks.
+- Relationship completeness is still validated per chunk: the cache merges repeated *rows*, it does not let a child reference a parent that appeared only in an earlier chunk.
+- The strategy is stateful across the run—use a fresh instance per pipeline.
+
+**Custom strategies.** A strategy receives a `FlushContext` exposing the scoped tables, mapped results, dependency graph, relationships, stats sink, telemetry callback, and the `session`/`is_supabase` target. Custom strategies implement persistence using those public fields plus `etielle.utils.topological_sort`.
 
 ## Upsert Behavior
 

--- a/user-guide/database-loading.qmd
+++ b/user-guide/database-loading.qmd
@@ -230,157 +230,32 @@ with Session(engine) as session:
     print(f"{user.name} has {len(user.posts)} posts")
 ```
 
-## Component-Scoped Flushing and Memory
+## Execution modes
 
-Pipelines with relationships are executed as independent **relationship components** (weakly connected subgraphs of the `link_to`/`backlink` graph). Each component is mapped, bound, flushed, and evicted before the next component runs. This bounds peak accumulator memory to the largest component instead of the entire dataset.
+etielle supports two execution shapes. **Resident** mode (`etl()`) maps your full JSON payload in memory; **streaming** mode (`stream()`) maps one key-complete chunk at a time, flushes it, and evicts it before the next chunk. Component-scoped flushing bounds peak mapping memory to the largest relationship component (resident) or one chunk plus eager tables (streaming).
 
-Tables with no relationship edges are batched into a single mapping pass for efficiency.
+For the mental model, decision flowcharts, chunk-source and flush-strategy choice, and operational guidance (commit cadence, sizing caches, spill directories), see [Scaling & Memory](scaling-and-memory.qmd).
 
-## Shared Tables with `load_eager()`
+### Streaming quick start
 
-When a shared dimension table (e.g. `tags`) is referenced by many independent subgraphs, the relationship graph collapses into one giant component and the memory win vanishes. Mark small shared tables as eager so they are loaded once and kept resident while other components are processed:
-
-```python
-result = (
-    etl(data)
-    .goto("tags").each()
-    .map_to(table=Tag, fields=[...])
-    .load_eager(Tag)          # resident across all components
-    .goto_root()
-    .goto("items").each()
-    .map_to(table=Item, fields=[...])
-    .link_to(Tag, by={"tag_id": "id"})
-    .load(session)
-    .run()
-)
-```
-
-`load_eager()` requires an explicit preceding `map_to()` for the same table.
-
-## Streaming and Chunked Execution
-
-For large or single-consumption inputs (paginated APIs, `ijson` streams), use `stream()` instead of `etl()`. Streaming mode processes **key-complete, relationship-complete** chunks: each chunk is mapped, validated, bound, flushed, and evicted before the next chunk begins.
+For large or single-consumption inputs (paginated APIs, `ijson` streams):
 
 ```python
 from etielle import stream, Field, TempField, get
 
-# One JSON root per chunk (default)
 result = (
     stream(record_iter)
     .goto("users").each()
     .map_to(table=User, fields=[...])
-    .load(session)
+    .load(session)   # required in streaming mode
     .run()
 )
 session.commit()
 ```
 
-**Requirements and restrictions:**
+Streaming requires `load()` before `run()`, key-complete and relationship-complete chunks, and rejects traversal-based `build_index()` and composite `link_to(by={...})` mappings. Pass shared dimension data via `load_eager()` and `eager_roots=` when parents are not repeated in every chunk.
 
-- `load()` is required before `run()` in streaming mode.
-- Chunks must include all relationship endpoints (or use `load_eager()` for shared parents).
-- Cross-chunk scattered merge (e.g. merging `users` and `profiles` from different chunks) is not supported.
-- Traversal-based `build_index()` and composite `by` mappings on `link_to()` are rejected.
-
-Pass resident eager data via `eager_roots=` when dimension tables are not repeated in every chunk:
-
-```python
-stream(chunks, eager_roots=tags_snapshot)
-    .goto("tags").each()
-    .map_to(table=Tag, fields=[...])
-    .load_eager(Tag)
-    ...
-```
-
-### Chunking helpers
-
-Producing correct chunks is part of the streaming contract, so etielle ships `ChunkSource` helpers rather than leaving boundary-finding to the caller.
-
-**`GroupByChunkSource` (single-pass group-by).** Given a `key` function, it reads the input once, accumulates consecutive records that share a key, and emits a chunk when the key changes. Peak memory is one chunk.
-
-```python
-from etielle import stream, GroupByChunkSource, Field, TempField, get
-
-# Each record is a parent subtree; group by the owning order id.
-source = GroupByChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
-
-stream(source)
-    .goto("orders").each()
-    .map_to(table=Order, fields=[Field("customer", get("customer")), TempField("id", get("id"))])
-    .goto_root()
-    .goto("items").each()
-    .map_to(table=LineItem, fields=[...])
-    .link_to(Order, by={"order_id": "id"})
-    .load(session)
-    .run()
-```
-
-- **Grouped-input requirement.** Grouping is *consecutive only*, so the input must already be grouped (or sorted) by `key`—the natural shape for paginated APIs and "one parent subtree at a time" feeds. If two records share a key but are separated by a record with a different key, they land in different chunks; that still satisfies key-completeness, but the runtime relationship-completeness check will raise if a chunk is then missing relationship endpoints. For unsorted input, sort by `key` first or use `ExternalPartitionChunkSource`.
-- **Pick a relationship-complete key.** Choose a key that is a *complete component root*—coarse enough that everything reachable through a relationship from a record sharing the key also shares it (e.g. the owning entity id), not merely a fine merge key. Grouping guarantees key-completeness for the chosen key; the runtime validation catches a key that is too fine.
-
-**`ExternalPartitionChunkSource` (disk-backed partitioner for unsorted input).** The two-pass complement to `GroupByChunkSource`: pass one serializes every record to a temporary spill file and builds a key→offsets index; pass two emits one chunk per distinct key (in first-appearance order) by reading that key's records back from disk. Records sharing a key are reunited no matter how far apart they arrive, so no pre-sorting is needed.
-
-```python
-from etielle import stream, ExternalPartitionChunkSource
-
-# Records for the same order may be interleaved with other orders.
-source = ExternalPartitionChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
-stream(source).goto(...)...
-```
-
-- **Trade-offs.** Peak record memory is one chunk (the current partition), but the whole dataset is written to temp storage and the offset index holds a few machine words per record for the duration of the stream. Pass two performs random reads, so prefer a fast local temp filesystem (override the location with `dir=`).
-- **Serialization.** Records round-trip through `dumps`/`loads` (default `json.dumps`/`json.loads`), so chunks yield reconstructed copies; pass custom callables for non-JSON records. The spill file is deleted when iteration finishes or the chunk iterator is closed.
-- The same relationship-complete-key guidance as `GroupByChunkSource` applies.
-
-**`PreSegmentedChunkSource` (passthrough).** If you already have an iterable of `Chunk` objects, hand it over directly—it yields them in order without buffering.
-
-```python
-from etielle import stream, PreSegmentedChunkSource, Chunk
-
-chunks = [Chunk(roots=(subtree,), sequential=True) for subtree in producer]
-stream(PreSegmentedChunkSource(chunks)).goto(...)...
-```
-
-### Why streaming bounds memory
-
-Streaming keeps peak memory flat regardless of dataset size: etielle maps a chunk, flushes it, and releases that chunk's accumulators before mapping the next, so it never holds more than one chunk (plus any resident `load_eager()` tables) at a time. The benchmark in `benchmarks/bench_issue_75.py` shows the Python heap peak staying flat under streaming while resident loading grows linearly with the dataset.
-
-On the SQLAlchemy side this needs no special handling: the session's identity map references *persistent* (flushed, clean) instances weakly, so once etielle drops its per-chunk references, CPython's garbage collector reclaims them. Transaction control still belongs to the caller—the `INSERT`s accumulate in the open transaction until you commit or roll back. For a very long stream, commit at a cadence that suits your durability needs; a single end-of-stream commit keeps everything in one transaction.
-
-### Flush strategies
-
-The chunk loop is strategy-agnostic: it calls `FlushStrategy.flush(ctx)` at each component boundary, and `stream(..., flush_strategy=...)` selects which strategy runs. Three strategies ship with etielle.
-
-**`KeyCompleteFlushStrategy` (default).** Plain insert/flush with no cross-chunk state, delegating to etielle's standard insert/bind logic. A row whose key conflicts with an already-stored row raises `IntegrityError` and aborts the chunk's transaction.
-
-**`UpsertFlushStrategy` (database-level conflict handling, SQLAlchemy only).** Resolves conflicts against rows that are already stored, for idempotent re-runs and streaming ingest that may re-encounter stored records:
-
-```python
-from etielle import stream, UpsertFlushStrategy
-
-stream(records, flush_strategy=UpsertFlushStrategy())                     # ON CONFLICT-style update
-stream(records, flush_strategy=UpsertFlushStrategy(on_conflict="skip"))   # skip conflicting rows
-```
-
-- `on_conflict="update"` (default) persists each instance with `session.merge()`: an existing row with the same primary key is overwritten (last write wins); otherwise the row is inserted. Conflict detection is by primary key, so instances need their key values set, and each merge can issue a per-row SELECT. A concurrent insert between that SELECT and the INSERT can still raise `IntegrityError`.
-- `on_conflict="skip"` inserts each instance inside a per-row `SAVEPOINT` and skips any row that raises `IntegrityError`—duplicate primary keys, unique-constraint conflicts (including concurrent-insert races), but also any other integrity violation. A child bound to a skipped parent is itself skipped, because the cascaded parent insert reproduces the conflict inside the child's `SAVEPOINT`. Skipped rows appear in `mapped` stats but in neither `inserted` nor `failed`.
-- Not a cross-chunk-merge substitute: merge policies (`AddPolicy` etc.) run only within a chunk's mapping pass, and `update` mode overwrites whole rows rather than merging fields.
-- For Supabase, use `load(upsert=True, upsert_on=...)` with the default strategy instead; the Supabase adapter performs native upserts.
-
-**`BufferedKeyFlushStrategy` (bounded cross-chunk key merge, SQLAlchemy only).** Keeps an LRU cache of the last `max_keys` flushed `(table, join key)` entries. When a later chunk maps a row whose key is still cached, its non-None scalar values are copied onto the already-persisted instance (an UPDATE at the next flush) instead of inserting a duplicate, and children mapped alongside the re-appearing row are relinked to the persisted instance:
-
-```python
-from etielle import stream, BufferedKeyFlushStrategy
-
-stream(records, flush_strategy=BufferedKeyFlushStrategy(max_keys=50_000))
-```
-
-- **Correctness is a heuristic bounded by cache size**, not a guarantee: once a key is evicted, a reappearing row inserts a new row (or raises `IntegrityError` under a unique constraint). Size `max_keys` for the worst-case reappearance gap, or use `ExternalPartitionChunkSource` for exact grouping.
-- Only tables with `join_on` participate; auto-keyed rows always insert because auto keys restart per chunk. Merge is last-non-None-write-wins per scalar attribute; collection attributes (e.g. `backlink()` lists) are not merged across chunks.
-- Relationship completeness is still validated per chunk: the cache merges repeated *rows*, it does not let a child reference a parent that appeared only in an earlier chunk.
-- The strategy is stateful across the run—use a fresh instance per pipeline.
-
-**Custom strategies.** A strategy receives a `FlushContext` exposing the scoped tables, mapped results, dependency graph, relationships, stats sink, telemetry callback, and the `session`/`is_supabase` target. Custom strategies implement persistence using those public fields plus `etielle.utils.topological_sort`.
+Chunk sources (`GroupByChunkSource`, `ExternalPartitionChunkSource`, `PreSegmentedChunkSource`) and flush strategies (`UpsertFlushStrategy`, `BufferedKeyFlushStrategy`) are documented in [Scaling & Memory](scaling-and-memory.qmd).
 
 ## Upsert Behavior
 
@@ -507,18 +382,9 @@ with Session(engine) as session:
 # Session is automatically closed
 ```
 
-### Handle Large Datasets in Batches
+### Handle Large Datasets
 
-```python
-BATCH_SIZE = 1000
-
-with Session(engine) as session:
-    for i in range(0, len(records), BATCH_SIZE):
-        batch = {"users": records[i:i + BATCH_SIZE]}
-        etl(batch).goto("users").each().map_to(...).load(session).run()
-
-    session.commit()
-```
+For datasets that do not fit comfortably in memory, use `stream()` with an appropriate chunk source rather than batching with `etl()`. Manual batching (`etl(batch).load(session).run()` in a loop) still peaks at the full batch size in mapping memory. See [Scaling & Memory](scaling-and-memory.qmd) for execution-mode and chunk-source guidance.
 
 ### Separate Transform and Load
 
@@ -753,6 +619,7 @@ result = (
 
 ## See also
 
+- [Scaling & Memory](scaling-and-memory.qmd) - Execution modes, chunk sources, flush strategies, and memory bounds
 - [Mapping Tables](mapping.qmd) - Defining output structure
 - [Relationships](relationships.qmd) - Linking tables before persistence
 - [Error Handling](error-handling.qmd) - Handling validation errors

--- a/user-guide/introduction-to-etl.qmd
+++ b/user-guide/introduction-to-etl.qmd
@@ -203,6 +203,7 @@ Learn more: [Transforms](transforms.qmd), [Mapping Tables](mapping.qmd), [Relati
 **Key features**:
 - `load(session)`: Configure database session
 - `run()`: Execute pipeline and flush to database by relationship component
+- `stream()`: Chunked execution for large or single-consumption inputs (see [Scaling & Memory](scaling-and-memory.qmd))
 - `load_eager(table)`: Keep shared dimension tables resident across components
 - Flushed instances are not retained in `PipelineResult.tables` (use stats/errors or query the DB)
 - You control the transaction (commit/rollback)

--- a/user-guide/scaling-and-memory.qmd
+++ b/user-guide/scaling-and-memory.qmd
@@ -1,0 +1,309 @@
+---
+title: "Scaling & Memory"
+---
+
+**What you'll learn**: What etielle holds in memory at each execution phase, when to use resident (`etl()`) versus streaming (`stream()`) execution, how to choose a chunk source and flush strategy, and what memory bounds etielle does *not* provide.
+
+For session setup, transactions, Supabase configuration, and persistence mechanics, see [Database Loading](database-loading.qmd).
+
+## Mental model: what lives in memory
+
+Every pipeline run moves data through the same phases. Understanding what is retained at each step is the key to sizing your ingest.
+
+| Phase | What etielle holds | When it is released |
+|-------|-------------------|---------------------|
+| **Map** | Per-table `MappingResult` accumulators (instances, indices, lookup values) | After flush and evict (streaming), or after each component cycle (resident) |
+| **Bind** | Same objects with relationship attributes populated | Same as map |
+| **Flush** | ORM instances in the session plus etielle's scoped references | etielle drops its references after flush; the session retains flushed rows until you commit |
+| **Resident eager** | `load_eager()` tables mapped once and kept in `bind_context` | Entire run (by design) |
+| **Strategy state** | e.g. `BufferedKeyFlushStrategy` LRU cache of recently flushed keys | Entire run, bounded by `max_keys` |
+| **External partition spill** | Temporary file plus in-memory offset index | Until chunk iteration finishes or the iterator is closed |
+
+```mermaid
+flowchart LR
+    subgraph per_chunk [Per chunk or component]
+        M[Map accumulators] --> B[Bind relationships]
+        B --> F[Flush to session]
+        F --> E[Evict etielle references]
+    end
+    E --> GC[CPython reclaims mapping objects]
+    F --> S[(Session / open transaction)]
+```
+
+**Key takeaway:** etielle bounds **mapping accumulator** memory. It does **not** bound session or transaction size, strategy cache size, resident eager tables, or external-partition disk usage. You control transaction scope via `session.commit()`.
+
+## Resident execution (`etl()`)
+
+Resident mode loads your JSON root(s) once and maps the full payload in memory:
+
+```python
+from etielle import etl
+
+result = (
+    etl(data)
+    .goto("users").each()
+    .map_to(table=User, fields=[...])
+    .load(session)
+    .run()
+)
+```
+
+### Component-scoped flush and evict
+
+Pipelines with relationships are executed as independent **relationship components** (weakly connected subgraphs of the `link_to`/`backlink` graph). Each component is mapped, bound, flushed, and evicted before the next component runs.
+
+Peak mapping memory is bounded by the **largest component**, not necessarily the entire dataset — but only when the relationship graph splits cleanly. Tables with no relationship edges are batched into a single mapping pass for efficiency.
+
+### When resident mode is enough
+
+- The full JSON payload fits comfortably in RAM.
+- You have a single root or a modest number of roots you can hold at once.
+- The relationship graph decomposes into reasonably sized components.
+
+### Shared dimensions and `load_eager()`
+
+When a shared dimension table (e.g. `tags`) is referenced by many independent subgraphs, the relationship graph collapses into one giant component and the per-component memory win vanishes. Mark small shared tables as eager so they are loaded once and kept resident while other components are processed:
+
+```python
+result = (
+    etl(data)
+    .goto("tags").each()
+    .map_to(table=Tag, fields=[...])
+    .load_eager(Tag)          # resident across all components
+    .goto_root()
+    .goto("items").each()
+    .map_to(table=Item, fields=[...])
+    .link_to(Tag, by={"tag_id": "id"})
+    .load(session)
+    .run()
+)
+```
+
+Resident eager tables stay in memory for the entire run. Size them for tables that are small relative to your fact data.
+
+## Streaming execution (`stream()`)
+
+For large or single-consumption inputs (paginated APIs, `ijson` streams), use `stream()` instead of `etl()`. Streaming processes **key-complete, relationship-complete** chunks: each chunk is mapped, validated, bound, flushed, and evicted before the next chunk begins.
+
+```python
+from etielle import stream
+
+result = (
+    stream(record_iter)
+    .goto("users").each()
+    .map_to(table=User, fields=[...])
+    .load(session)   # required in streaming mode
+    .run()
+)
+session.commit()
+```
+
+Peak mapping memory is approximately **one chunk** plus any resident `load_eager()` tables — flat regardless of total dataset size. The benchmark in `benchmarks/bench_issue_75.py` demonstrates Python heap peak staying flat under streaming while resident loading grows with the dataset:
+
+```bash
+uv run python benchmarks/bench_issue_75.py --scale 2000
+```
+
+### Streaming requirements
+
+- `load()` is required before `run()` in streaming mode.
+- Each chunk must include all relationship endpoints, or use `load_eager()` for shared parents present in every chunk.
+- Cross-chunk scattered merge (e.g. merging `users` and `profiles` from different chunks) is not supported.
+- Traversal-based `build_index()` and composite `by` mappings on `link_to()` are rejected.
+
+Pass resident eager data via `eager_roots=` when dimension tables are not repeated in every chunk:
+
+```python
+stream(chunks, eager_roots=tags_snapshot)
+    .goto("tags").each()
+    .map_to(table=Tag, fields=[...])
+    .load_eager(Tag)
+    ...
+```
+
+### SQLAlchemy session behavior
+
+Once etielle drops its per-chunk references after flush, CPython's garbage collector reclaims mapping objects. The session's identity map references persistent (flushed, clean) instances weakly, so no special cleanup is required on the SQLAlchemy side.
+
+Transaction control still belongs to you: `INSERT`s accumulate in the open transaction until you commit or roll back. For very long streams, commit at a cadence that suits your durability needs; a single end-of-stream commit keeps everything in one transaction but grows the session's transaction scope.
+
+## Choosing an execution mode
+
+```mermaid
+flowchart TD
+    Start([Sizing an ingest]) --> Q1{Entire payload fits<br/>comfortably in RAM?}
+    Q1 -->|Yes| Q2{Single JSON root<br/>or modest batch?}
+    Q1 -->|No| Stream[Use stream]
+    Q2 -->|Yes| Etl[Use etl]
+    Q2 -->|No, many roots| Q3{Can you process<br/>one root at a time?}
+    Q3 -->|Yes| Stream
+    Q3 -->|No| EtlWarn["etl with all roots:<br/>peak ≈ full dataset"]
+
+    Stream --> LoadReq[Requires load before run]
+    Etl --> LoadOpt[load optional]
+```
+
+## Choosing a chunk source
+
+Chunk sources are only relevant for `stream()`. Producing correct chunks is part of the streaming contract — each chunk must be key-complete and relationship-complete. See [Relationships](relationships.qmd) for how `link_to` shapes the component graph.
+
+::: {.callout-important}
+## Pick a relationship-complete key
+
+Whether you group with `GroupByChunkSource` or partition with `ExternalPartitionChunkSource`, choose a key that is a **complete component root** — coarse enough that every record reachable through a relationship from one record sharing the key also shares it (e.g. the owning entity id), not merely a fine merge key. Grouping guarantees key-completeness for the chosen key; the runtime relationship-completeness check catches a key that is too fine.
+:::
+
+```mermaid
+flowchart TD
+    S([Using stream]) --> Q1{Already have<br/>Chunk objects?}
+    Q1 -->|Yes| Pre[PreSegmentedChunkSource]
+    Q1 -->|No| Q2{Records sharing a key<br/>can be far apart?}
+    Q2 -->|No, consecutive or sorted| Group[GroupByChunkSource]
+    Q2 -->|Yes, arbitrary order| Ext[ExternalPartitionChunkSource]
+    Q1 -->|One record per chunk| Default["Iterable / OneRecordPerChunkSource"]
+
+    Group --> Key[Relationship-complete key]
+    Ext --> Key
+    Pre --> Key
+    Default --> Key
+```
+
+| Chunk source | When to use | Record RAM | Other cost |
+|--------------|-------------|--------------|------------|
+| **Iterable / `OneRecordPerChunkSource`** | One JSON root per chunk; simplest streaming shape | One record | None |
+| **`GroupByChunkSource`** | Input is grouped or sorted by key; consecutive records with the same key arrive together | One chunk (current key group) | Single pass, no disk |
+| **`ExternalPartitionChunkSource`** | Keys can reappear arbitrarily far apart; input is unsorted | One chunk (current partition) | Full-dataset temp file + offset index |
+| **`PreSegmentedChunkSource`** | You already produce `Chunk` objects with known boundaries | Whatever the upstream holds | None (passthrough) |
+
+### `GroupByChunkSource`
+
+Single-pass group-by over consecutive records:
+
+```python
+from etielle import stream, GroupByChunkSource
+
+source = GroupByChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
+stream(source).goto(...)...
+```
+
+Grouping is **consecutive only**. If two records share a key but are separated by a record with a different key, they land in separate chunks. That still satisfies key-completeness, but the relationship-completeness check will raise if a chunk is then missing endpoints. For unsorted input, use `ExternalPartitionChunkSource` instead.
+
+### `ExternalPartitionChunkSource`
+
+Two-pass disk-backed partitioner for arbitrarily ordered input. Pass one serializes every record to a temporary spill file and builds a key→offsets index; pass two emits one chunk per distinct key by reading records back from disk:
+
+```python
+from etielle import stream, ExternalPartitionChunkSource
+
+source = ExternalPartitionChunkSource(record_iter, key=lambda r: r["orders"][0]["id"])
+stream(source).goto(...)...
+```
+
+- Peak **record** memory is one chunk; the **full dataset** is written to temp storage.
+- The offset index holds a few machine words per record for the duration of the stream.
+- Pass two performs random reads — prefer a fast local temp filesystem (`dir=` overrides the location).
+- Records round-trip through `dumps`/`loads` (default JSON); chunks yield reconstructed copies.
+
+### `PreSegmentedChunkSource`
+
+Passthrough when you already have an iterable of `Chunk` objects:
+
+```python
+from etielle import stream, PreSegmentedChunkSource, Chunk
+
+chunks = [Chunk(roots=(subtree,), sequential=True) for subtree in producer]
+stream(PreSegmentedChunkSource(chunks)).goto(...)...
+```
+
+## Choosing a flush strategy
+
+The chunk loop calls `FlushStrategy.flush(ctx)` at each component boundary. Pass a strategy via `stream(..., flush_strategy=...)`. Resident `etl()` runs use the same strategy hook at component boundaries.
+
+```mermaid
+flowchart TD
+    F([Flush at component boundary]) --> Q1{Target?}
+    Q1 -->|Supabase| Supa["Default strategy +<br/>load(upsert=True, upsert_on=...)"]
+    Q1 -->|SQLAlchemy| Q2{How should conflicts<br/>and reappearing keys behave?}
+    Q2 -->|Plain insert| Default[KeyCompleteFlushStrategy]
+    Q2 -->|Overwrite existing row by PK| Upsert["UpsertFlushStrategy<br/>on_conflict='update'"]
+    Q2 -->|Skip conflicting rows / races| Skip["UpsertFlushStrategy<br/>on_conflict='skip'"]
+    Q2 -->|Same natural key reappears<br/>within bounded gap| Buf[BufferedKeyFlushStrategy]
+
+    Buf --> Size["Size max_keys to<br/>worst reappearance gap"]
+```
+
+| Strategy | Cross-chunk state | Use when |
+|----------|-------------------|----------|
+| **`KeyCompleteFlushStrategy`** (default) | None | Clean inserts; duplicate keys against stored rows raise `IntegrityError` |
+| **`UpsertFlushStrategy`** | None (DB resolves) | Idempotent re-runs (`update`) or skip-on-conflict ingest (`skip`); SQLAlchemy only |
+| **`BufferedKeyFlushStrategy`** | LRU cache of `max_keys` entries | Late-arriving rows for the same `join_on` key within a bounded reappearance gap; SQLAlchemy only |
+
+### `KeyCompleteFlushStrategy`
+
+Default behavior: plain `session.add()` and flush with no cross-chunk state. Delegates to etielle's standard insert and relationship-binding logic.
+
+### `UpsertFlushStrategy`
+
+Database-level conflict handling for SQLAlchemy (real upsert via `session.merge()`, not `add()`):
+
+```python
+from etielle import stream, UpsertFlushStrategy
+
+stream(records, flush_strategy=UpsertFlushStrategy())                    # overwrite by PK
+stream(records, flush_strategy=UpsertFlushStrategy(on_conflict="skip"))    # skip conflicts
+```
+
+- **`update`** (default): `session.merge()` — existing rows with the same primary key are overwritten (last write wins).
+- **`skip`**: per-row `SAVEPOINT` insert; rows raising `IntegrityError` are skipped (duplicate keys, unique constraints, concurrent-insert races). Children bound to a skipped parent are skipped too, because the cascaded parent insert reproduces the conflict inside the child's savepoint.
+- Not a cross-chunk merge substitute: merge policies (`AddPolicy` etc.) run only within a chunk's mapping pass.
+- For Supabase, use `load(upsert=True, upsert_on=...)` with the default strategy instead.
+
+### `BufferedKeyFlushStrategy`
+
+Bounded LRU cache of recently flushed `(table, join_on key)` → instance entries:
+
+```python
+from etielle import stream, BufferedKeyFlushStrategy
+
+stream(records, flush_strategy=BufferedKeyFlushStrategy(max_keys=50_000))
+```
+
+When a later chunk maps a row whose key is still cached, non-None scalar values are copied onto the already-persisted instance (an UPDATE at the next flush) instead of inserting a duplicate. Children mapped alongside a re-appearing parent are relinked to the persisted instance.
+
+**Correctness is a heuristic bounded by cache size**, not a guarantee: once a key is evicted, a reappearing row inserts a new row (or raises under a unique constraint). Size `max_keys` for your worst-case reappearance gap, or prefer `ExternalPartitionChunkSource` when keys can be arbitrarily far apart and exact grouping matters.
+
+Only tables with `join_on` participate; auto-keyed rows always insert because auto keys restart per chunk. The strategy is stateful across the run — use a fresh instance per pipeline.
+
+## What etielle does not bound
+
+| Concern | Why |
+|---------|-----|
+| **Session / transaction size** | Flushed rows accumulate in the open transaction until you `commit()` |
+| **`BufferedKeyFlushStrategy` cache** | Up to `max_keys` live ORM instances held for the run |
+| **`load_eager()` resident tables** | Entire eager table stays mapped for the run (intentional) |
+| **External partition spill** | Full dataset on disk plus offset index (not RAM, but not free) |
+| **Cross-chunk scattered merge** | Unsupported by design — not a memory knob, a correctness limit |
+
+## Operational guidance
+
+### Commit cadence
+
+For long streaming runs, periodic `session.commit()` limits transaction scope and session growth. A single end-of-stream commit is simpler but keeps the entire ingest in one transaction. Choose based on durability requirements and database behavior under large open transactions.
+
+### Sizing `max_keys` (buffered strategy)
+
+Estimate the maximum number of distinct `(table, join_on key)` pairs that can reappear before you finish the stream, within the window where late rows still need to merge. If reappearance distance is unbounded or unknown, do not rely on `BufferedKeyFlushStrategy` alone — use `ExternalPartitionChunkSource` to group records correctly before mapping.
+
+### Choosing spill `dir=` (external partition)
+
+Point `ExternalPartitionChunkSource(..., dir=...)` at fast local storage. Pass two reads records back in arbitrary key order; network filesystems add latency without helping correctness.
+
+### Manual batching with `etl()`
+
+Splitting a large dataset into multiple `etl(batch).load(session).run()` calls inside one transaction is a resident pattern. Each batch still peaks at the full batch size in mapping memory. For true flat peak memory over an unbounded stream, use `stream()` with an appropriate chunk source.
+
+## See also
+
+- [Database Loading](database-loading.qmd) — sessions, transactions, Supabase, upsert configuration
+- [Relationships](relationships.qmd) — `link_to`, component graphs, relationship-complete chunks
+- [Error Handling](error-handling.qmd) — telemetry during mapping and flush


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the three deferred items from #77 as additive `ChunkSource`/`FlushStrategy` implementations with no core-loop changes.

## `ExternalPartitionChunkSource` (H2, disk-backed external partition)

Two-pass partitioner for arbitrarily-ordered input: pass one serializes every record to a temporary spill file and builds an in-memory key→offsets index; pass two emits one key-complete chunk per distinct key (first-appearance order) by reading records back from disk. Records sharing a key are reunited no matter how far apart they arrive, unlike the consecutive-only `GroupByChunkSource`.

- One-chunk record memory, full-dataset temp storage, offset index of a few machine words per record.
- Records round-trip through `dumps`/`loads` (default JSON); custom callables supported for non-JSON records. Spill file location is configurable via `dir=` and is cleaned up on completion or early iterator close.

## `UpsertFlushStrategy` (option a, plus the skip-on-conflict variant requested in the issue comment)

Database-level conflict handling for the SQLAlchemy path (real upsert via `session.merge`, not `add()`):

- `on_conflict="update"` (default): persist each instance with `session.merge()` — existing rows with the same primary key are overwritten (last write wins), new rows are inserted. Suited to idempotent re-runs.
- `on_conflict="skip"`: per-row `SAVEPOINT` insert that skips any row raising `IntegrityError` (duplicate PK, unique-constraint conflict including concurrent-insert races). Children bound to a skipped parent are skipped too, since the cascaded parent insert reproduces the conflict inside the child's SAVEPOINT. This matches the streaming dedup semantics described in the Formettle use case.
- Raises for Supabase with a pointer to `load(upsert=True, upsert_on=...)`, which already performs native upserts.
- Documented limits from #9: not a cross-chunk-merge substitute, merge policies still run only within a chunk's mapping pass.

## `BufferedKeyFlushStrategy` (option b)

Bounded LRU cache of the last `max_keys` flushed `(table, join key)` → instance entries. A later chunk that maps a row for a cached key merges its non-None scalar values onto the already-persisted instance (an UPDATE at next flush) instead of inserting a duplicate; children mapped alongside a re-appearing parent are relinked to the persisted instance so relationship cascades cannot insert duplicate parents.

- Documented clearly as a heuristic bounded by cache size: after eviction, a reappearing key inserts a new row (or raises under a unique constraint).
- Only `join_on` tables participate — auto keys restart per chunk and would collide spuriously, so auto-keyed rows always insert.

## Supporting fix

`PipelineBuilder._merge_mapping_results` no longer transplants private attributes (e.g. SQLAlchemy's `_sa_instance_state`) onto retained instances, and secondary-index entries are redirected to the retained duplicate. This surfaced when `ExternalPartitionChunkSource` produced multi-record sequential chunks whose repeated `join_on` keys merged across roots: relationship binding could resolve to a discarded duplicate instance, causing `ObjectDereferencedError` / duplicate-PK inserts.

## Tests and docs

- `tests/test_issue_77.py`: 22 tests covering partitioning of unsorted input, spill-file cleanup (including early close), streaming integration, upsert update/skip semantics (including skip cascade to children and upsert telemetry), buffered-key merge, eviction, auto-key behavior, and parent relinking.
- `docs/database-loading.qmd`: new "Flush strategies" section and `ExternalPartitionChunkSource` docs; removed the stale "H2 is deferred" notes.
- Full suite: 362 passed, 4 skipped. `ruff check etielle/` clean; mypy unchanged from `main`.

Closes #77.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535de120-25e5-462a-b472-bb5a3d973dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535de120-25e5-462a-b472-bb5a3d973dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

