### PR TITLE
fix: validate link_to fk= in _prepare_execution for SQLAlchemy

### DIFF
--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1697,6 +1697,15 @@ class PipelineBuilder:
                 "which is only available with SQLAlchemy/SQLModel."
             )
 
+        if self._session is not None and not self._is_supabase_client(self._session):
+            for rel in link_to_rels:
+                if rel.get("fk"):
+                    raise ValueError(
+                        "fk parameter on link_to() is only supported for Supabase. "
+                        f"Got fk={rel['fk']!r} on {rel['child_table']!r} -> "
+                        f"{rel['parent_table']!r}."
+                    )
+
         components = partition_components(dep_graph, emission_tables, eager_tables)
 
         return {
@@ -1796,24 +1805,6 @@ class PipelineBuilder:
                 is_supabase=self._is_supabase_client(self._session),
                 builder=self,
             )
-            if self._is_supabase_client(self._session):
-                if prepared["backlink_rels"]:
-                    raise ValueError(
-                        "backlink() is not supported with Supabase. "
-                        "backlink() relies on ORM-native many-to-many handling "
-                        "which is only available with SQLAlchemy/SQLModel."
-                    )
-            else:
-                for rel in self._relationships:
-                    if rel.get("fk"):
-                        import warnings
-
-                        warnings.warn(
-                            f"fk parameter on link_to() is only supported for Supabase. "
-                            f"Ignoring fk={rel['fk']} for {rel['child_table']} -> {rel['parent_table']}.",
-                            UserWarning,
-                            stacklevel=2,
-                        )
             strategy.flush(ctx)
         elif retain_instances:
             for table_name, mapping_result in eager_results.items():

--- a/tests/test_issue_86.py
+++ b/tests/test_issue_86.py
@@ -1,0 +1,70 @@
+"""Tests for issue #86: fk= on link_to() must fail for SQLAlchemy without load_eager()."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, etl, get
+
+
+Base = declarative_base()
+
+
+class Parent(Base):
+    __tablename__ = "ps_86"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class Child(Base):
+    __tablename__ = "cs_86"
+    id = Column(Integer, primary_key=True)
+    p_id = Column(Integer, ForeignKey("ps_86.id"))
+    p = relationship("Parent")
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _pipeline_with_fk(*, session=None, eager_parent: bool = False):
+    builder = (
+        etl({"ps": [{"id": 1, "name": "a"}], "cs": [{"pid": 1}]})
+        .goto("ps")
+        .each()
+        .map_to(
+            table=Parent,
+            fields=[Field("name", get("name")), TempField("id", get("id"))],
+        )
+        .goto_root()
+        .goto("cs")
+        .each()
+        .map_to(table=Child, fields=[TempField("pid", get("pid"))])
+        .link_to(Parent, by={"pid": "id"}, fk={"p_id": "id"})
+    )
+    if eager_parent:
+        builder = builder.load_eager(Parent)
+    if session is not None:
+        builder = builder.load(session)
+    return builder
+
+
+class TestIssue86FkValidation:
+    def test_fk_on_link_to_raises_for_sqlalchemy_without_load_eager(self):
+        """fk= must be rejected before eager phase when no load_eager() is used."""
+        with pytest.raises(ValueError, match="fk parameter on link_to.*Supabase"):
+            _pipeline_with_fk(session=_session()).run()
+
+    def test_fk_on_link_to_raises_for_sqlalchemy_with_load_eager(self):
+        """fk= is rejected for SQLAlchemy even when load_eager() is configured."""
+        with pytest.raises(ValueError, match="fk parameter on link_to.*Supabase"):
+            _pipeline_with_fk(session=_session(), eager_parent=True).run()
+
+    def test_fk_on_link_to_without_load_does_not_raise(self):
+        """Without load(), adapter type is unknown so fk= is not validated."""
+        result = _pipeline_with_fk().run()
+        assert "cs_86" in result.tables


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #86

## Problem

The `UserWarning` for `link_to(..., fk=...)` on a SQLAlchemy session lived only inside `_run_eager_phase`, which returns early when there are no eager tables. SQLAlchemy pipelines with `fk=` supplied and no `load_eager()` silently ignored `fk` with no warning or error.

## Solution

Move `fk` parameter validation into `_prepare_execution`, alongside the existing backlink+Supabase check. SQLAlchemy pipelines with `fk=` now raise `ValueError` immediately (hard error, matching the backlink validation pattern) regardless of eager configuration.

## Changes

- Validate `link_to(..., fk=...)` in `_prepare_execution` when a non-Supabase session is configured
- Remove the redundant warning block from `_run_eager_phase`
- Add regression tests in `tests/test_issue_86.py`

## Testing

- `pytest tests/test_issue_86.py -v` — 3 passed
- `pytest tests/test_fluent_sqlalchemy.py tests/test_supabase_adapter.py tests/test_fluent.py -q` — 148 passed, 4 skipped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f28ea85b-8e6a-49ae-9b46-29266eb58686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f28ea85b-8e6a-49ae-9b46-29266eb58686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

