### PR TITLE
Document UpsertFlushStrategy idempotency requires PK-keyed tables

### DIFF
--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -346,7 +346,10 @@ class UpsertFlushStrategy:
     - ``on_conflict="update"`` (default): each instance is persisted with
       ``session.merge()``. If a row with the same primary key exists, its
       columns are overwritten with the incoming values (last write wins);
-      otherwise the row is inserted. Suited to idempotent re-runs.
+      otherwise the row is inserted. Suited to idempotent re-runs only when
+      every table you expect to dedupe supplies primary key values (via
+      ``join_on`` or natural keys); auto-keyed rows without PK values are
+      inserted as new rows on each run.
     - ``on_conflict="skip"``: each instance is inserted inside a per-row
       ``SAVEPOINT``; a row that raises ``IntegrityError`` (duplicate primary
       key or unique constraint, including a concurrent-insert race) is rolled

--- a/user-guide/scaling-and-memory.qmd
+++ b/user-guide/scaling-and-memory.qmd
@@ -235,7 +235,7 @@ flowchart TD
 | Strategy | Cross-chunk state | Use when |
 |----------|-------------------|----------|
 | **`KeyCompleteFlushStrategy`** (default) | None | Clean inserts; duplicate keys against stored rows raise `IntegrityError` |
-| **`UpsertFlushStrategy`** | None (DB resolves) | Idempotent re-runs (`update`) or skip-on-conflict ingest (`skip`); SQLAlchemy only |
+| **`UpsertFlushStrategy`** | None (DB resolves) | Re-runs when all tables have mappable PKs (`update`) or skip-on-conflict ingest (`skip`); SQLAlchemy only |
 | **`BufferedKeyFlushStrategy`** | LRU cache of `max_keys` entries | Late-arriving rows for the same `join_on` key within a bounded reappearance gap; SQLAlchemy only |
 
 ### `KeyCompleteFlushStrategy`
@@ -253,7 +253,13 @@ stream(records, flush_strategy=UpsertFlushStrategy())                    # overw
 stream(records, flush_strategy=UpsertFlushStrategy(on_conflict="skip"))    # skip conflicts
 ```
 
-- **`update`** (default): `session.merge()` — existing rows with the same primary key are overwritten (last write wins).
+::: {.callout-important}
+## PK keys required for idempotent re-runs
+
+`UpsertFlushStrategy(on_conflict="update")` deduplicates rows only when etielle can supply a **mappable primary key** at flush time — typically via `join_on` on `map_to()` or natural keys populated before merge. Tables mapped without `join_on` (auto-increment or DB-generated PKs) are inserted as **new rows on every run**, even when parent rows merge correctly. For idempotent re-runs across **all** tables in the pipeline, ensure every table you expect to dedupe has keys mapped before flush.
+:::
+
+- **`update`** (default): `session.merge()` — existing rows with the same primary key are overwritten (last write wins). Applies per table: only rows with primary key values participate in merge; auto-keyed child rows accumulate on each re-run.
 - **`skip`**: per-row `SAVEPOINT` insert; rows raising `IntegrityError` are skipped (duplicate keys, unique constraints, concurrent-insert races). Children bound to a skipped parent are skipped too, because the cascaded parent insert reproduces the conflict inside the child's savepoint.
 - Not a cross-chunk merge substitute: merge policies (`AddPolicy` etc.) run only within a chunk's mapping pass.
 - For Supabase, use `load(upsert=True, upsert_on=...)` with the default strategy instead.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #90

## Summary

Clarifies that `UpsertFlushStrategy(on_conflict="update")` only supports idempotent re-runs when every table you expect to dedupe has a mappable primary key at flush time. Auto-keyed tables (no `join_on`) still insert a new row on each run.

## Changes

- Add a prominent callout under the `UpsertFlushStrategy` section in `user-guide/scaling-and-memory.qmd`
- Update the strategy comparison table and `update` mode bullet to reflect PK-keyed deduplication
- Tighten the `UpsertFlushStrategy` class docstring in `etielle/chunking.py`

## Testing

Documentation-only change; no code behavior modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a5775fc-816e-433b-9b25-3d345e078d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a5775fc-816e-433b-9b25-3d345e078d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

