### PR TITLE
fix: expose flush_strategy on etl() entry point

### DIFF
--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -2058,13 +2058,19 @@ class PipelineBuilder:
         )
 
 
-def etl(*roots: Any, errors: ErrorMode = "collect", indices: dict[str, dict[Any, Any]] | None = None) -> PipelineBuilder:
+def etl(
+    *roots: Any,
+    errors: ErrorMode = "collect",
+    indices: dict[str, dict[Any, Any]] | None = None,
+    flush_strategy: Any | None = None,
+) -> PipelineBuilder:
     """Entry point for fluent E→T→L pipelines.
 
     Args:
         *roots: One or more JSON objects to process.
         errors: Error handling mode - "collect" (default) or "fail_fast".
         indices: Pre-built lookup indices for use with lookup() transform.
+        flush_strategy: Optional flush strategy (defaults to ``KeyCompleteFlushStrategy``).
 
     Returns:
         A PipelineBuilder for chaining navigation and mapping calls.
@@ -2079,7 +2085,7 @@ def etl(*roots: Any, errors: ErrorMode = "collect", indices: dict[str, dict[Any,
             .run()
         )
     """
-    return PipelineBuilder(roots, errors, indices)
+    return PipelineBuilder(roots, errors, indices, flush_strategy=flush_strategy)
 
 
 def stream(

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -244,8 +244,15 @@ class TestEtlEntryPoint:
         builder = etl({}, errors="fail_fast")
         assert builder._error_mode == "fail_fast"
 
+    def test_etl_accepts_flush_strategy(self):
+        """etl() forwards flush_strategy to PipelineBuilder."""
+        from etielle.fluent import etl
+        from etielle.chunking import UpsertFlushStrategy
 
-class TestGotoRoot:
+        strategy = UpsertFlushStrategy()
+        builder = etl({}, flush_strategy=strategy)
+        assert builder._flush_strategy is strategy
+
     """Tests for goto_root() navigation."""
 
     def test_goto_root_returns_self(self):

--- a/tests/test_issue_88.py
+++ b/tests/test_issue_88.py
@@ -1,0 +1,55 @@
+"""Tests for issue #88: etl() accepts flush_strategy."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from etielle import Field, TempField, etl, get
+from etielle.chunking import FlushContext, KeyCompleteFlushStrategy
+
+
+Base = declarative_base()
+
+
+class ResidentUser(Base):
+    __tablename__ = "resident_users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class TestEtlFlushStrategy:
+    def test_etl_uses_custom_flush_strategy(self):
+        seen: list[FlushContext] = []
+
+        class RecordingStrategy(KeyCompleteFlushStrategy):
+            def flush(self, ctx: FlushContext) -> None:
+                seen.append(ctx)
+                super().flush(ctx)
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        (
+            etl({"users": [{"id": 1, "name": "A"}]}, flush_strategy=RecordingStrategy())
+            .goto("users")
+            .each()
+            .map_to(
+                table=ResidentUser,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load(session)
+            .run()
+        )
+
+        assert len(seen) >= 1
+        ctx = seen[0]
+        assert "resident_users" in ctx.scope_tables
+        assert "resident_users" in ctx.bind_context
+        assert ctx.session is session
+        session.close()

--- a/user-guide/scaling-and-memory.qmd
+++ b/user-guide/scaling-and-memory.qmd
@@ -217,7 +217,7 @@ stream(PreSegmentedChunkSource(chunks)).goto(...)...
 
 ## Choosing a flush strategy
 
-The chunk loop calls `FlushStrategy.flush(ctx)` at each component boundary. Pass a strategy via `stream(..., flush_strategy=...)`. Resident `etl()` runs use the same strategy hook at component boundaries.
+The chunk loop calls `FlushStrategy.flush(ctx)` at each component boundary. Pass a strategy via `stream(..., flush_strategy=...)` or `etl(..., flush_strategy=...)`.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #88 by adding a `flush_strategy` keyword argument to `etl()`, mirroring `stream()`.

Resident pipelines already call `FlushStrategy.flush(ctx)` at component boundaries via `PipelineBuilder._get_flush_strategy()`, but the public `etl()` entry point did not accept or forward the parameter. That left a doc/API mismatch with `user-guide/scaling-and-memory.qmd`.

## Changes

- **`etl(..., flush_strategy=...)`** — forwards the strategy to `PipelineBuilder`
- **Docs** — updated the flush-strategy section to mention both entry points
- **Tests** — unit test for parameter forwarding plus integration test that a custom strategy runs during resident execution

## Example

```python
from etielle import etl, UpsertFlushStrategy

result = (
    etl(data, flush_strategy=UpsertFlushStrategy())
    .goto("users").each()
    .map_to(table=User, fields=[...])
    .load(session)
    .run()
)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-697c3aea-97ee-4459-910a-68fce0266f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-697c3aea-97ee-4459-910a-68fce0266f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

