### PR TITLE
fix: validate multi-root pipelines for all sequential chunk sources

### DIFF
--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from etielle.fluent import PipelineBuilder, TableStats
@@ -50,6 +50,8 @@ class OneRecordPerChunkSource:
     on the first pass, matching the single-consumption nature of streaming
     sources; running the pipeline again would yield no chunks.
     """
+
+    emits_sequential_only: ClassVar[bool] = True
 
     def __init__(self, records: Iterator[Any] | Sequence[Any]) -> None:
         self._records = records
@@ -106,6 +108,8 @@ class GroupByChunkSource:
         key: Function mapping a record to its grouping key. Adjacent records
             with equal keys are batched into the same chunk.
     """
+
+    emits_sequential_only: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -187,6 +191,8 @@ class ExternalPartitionChunkSource:
         dumps: Serializer from record to ``str`` (default ``json.dumps``).
         loads: Deserializer from ``str`` to record (default ``json.loads``).
     """
+
+    emits_sequential_only: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/etielle/fluent.py
+++ b/etielle/fluent.py
@@ -1731,19 +1731,17 @@ class PipelineBuilder:
                     f"on link_to(); got {rel['by']!r} for {rel['child_table']!r}."
                 )
 
-        from etielle.chunking import OneRecordPerChunkSource
-
         referenced_indices = {e["root_index"] for e in self._emissions}
         multi_root_indices = sorted(i for i in referenced_indices if i > 0)
-        if multi_root_indices and isinstance(
-            self._chunk_source, OneRecordPerChunkSource
+        if multi_root_indices and getattr(
+            self._chunk_source, "emits_sequential_only", False
         ):
             raise ValueError(
                 "This pipeline references goto_root() index(es) "
                 f"{multi_root_indices}, which requires multi-root chunks, but the "
-                "streaming source yields one root per chunk. Pass a ChunkSource that "
-                "yields multi-root Chunks (sequential=False), or remove the "
-                "multi-root goto_root() calls."
+                "streaming source yields sequential-only chunks (one root index per "
+                "chunk). Pass a ChunkSource that yields multi-root Chunks "
+                "(sequential=False), or remove the multi-root goto_root() calls."
             )
 
     def _run_eager_phase(

--- a/tests/test_issue_89.py
+++ b/tests/test_issue_89.py
@@ -1,0 +1,54 @@
+"""Tests for issue #89: static multi-root validation for sequential chunk sources."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from etielle import Field, TempField, get, stream
+from etielle.chunking import (
+    ExternalPartitionChunkSource,
+    GroupByChunkSource,
+    OneRecordPerChunkSource,
+)
+
+
+def _multi_root_pipeline(source):
+    return (
+        stream(source)
+        .goto("users")
+        .each()
+        .map_to(table="users", join_on=["id"], fields=[Field("id", get("id"))])
+        .goto_root(1)
+        .goto("profiles")
+        .each()
+        .map_to(table="users", join_on=["id"], fields=[TempField("id", get("uid"))])
+        .load(MagicMock())
+    )
+
+
+class TestSequentialOnlyMultiRootValidation:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            OneRecordPerChunkSource([{"users": []}, {"profiles": []}]),
+            GroupByChunkSource(
+                [{"users": [{"id": 1}]}],
+                key=lambda r: r["users"][0]["id"],
+            ),
+            ExternalPartitionChunkSource(
+                [{"users": [{"id": 1}]}],
+                key=lambda r: r["users"][0]["id"],
+            ),
+        ],
+        ids=["OneRecordPerChunkSource", "GroupByChunkSource", "ExternalPartitionChunkSource"],
+    )
+    def test_rejects_multi_root_pipeline_statically(self, source):
+        with pytest.raises(ValueError, match="requires multi-root chunks"):
+            _multi_root_pipeline(source).run()
+
+    def test_emits_sequential_only_marker(self):
+        assert OneRecordPerChunkSource.emits_sequential_only is True
+        assert GroupByChunkSource.emits_sequential_only is True
+        assert ExternalPartitionChunkSource.emits_sequential_only is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #89 by extending static streaming validation to all chunk sources that only emit sequential chunks.

Previously, `_validate_streaming_pipeline` rejected multi-root `goto_root()` pipelines only when the chunk source was `OneRecordPerChunkSource`. `GroupByChunkSource` and `ExternalPartitionChunkSource` also emit `sequential=True` chunks exclusively, but the same misconfiguration was caught only at runtime on the first chunk — after the eager phase may already have flushed.

## Changes

- Add an `emits_sequential_only` class marker on `OneRecordPerChunkSource`, `GroupByChunkSource`, and `ExternalPartitionChunkSource`.
- Update `_validate_streaming_pipeline` to check this marker instead of a hard-coded `isinstance` check for `OneRecordPerChunkSource`.
- Slightly clarify the static error message to refer to "sequential-only chunks" rather than "one root per chunk".
- Add regression tests in `tests/test_issue_89.py`.

## Testing

- `pytest tests/test_issue_89.py tests/test_issue_75.py::TestStreamingValidation` — 9 passed
- Full suite — 366 passed, 4 skipped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7222c8d7-ef5e-45ab-a991-bb4d4c58b81b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7222c8d7-ef5e-45ab-a991-bb4d4c58b81b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

