### PR TITLE
fix: prevent UpsertFlushStrategy merge cascade from duplicating parents

### DIFF
--- a/etielle/chunking.py
+++ b/etielle/chunking.py
@@ -336,6 +336,22 @@ def _copy_instance_state(target: Any, incoming: Any) -> None:
         setattr(target, attr_name, value)
 
 
+def _replace_merged_instance(
+    result: Any,
+    key: tuple[Any, ...],
+    instance: Any,
+    merged: Any,
+    replacements: dict[int, Any],
+) -> None:
+    """Record a merge replacement and keep instances/indices consistent."""
+    replacements[id(instance)] = merged
+    result.instances[key] = merged
+    for field_index in result.indices.values():
+        for lookup_value, indexed in field_index.items():
+            if indexed is instance:
+                field_index[lookup_value] = merged
+
+
 class UpsertFlushStrategy:
     """Streaming strategy with database-level conflict handling (SQLAlchemy).
 
@@ -397,6 +413,15 @@ class UpsertFlushStrategy:
         from etielle.telemetry import FlushStarted, _emit
         from etielle.utils import topological_sort
 
+        parent_attrs: dict[str, list[str]] = {}
+        for rel in ctx.link_to_rels:
+            parent_attrs.setdefault(rel["child_table"], []).append(
+                _parent_attr_name(rel["parent_table"])
+            )
+        # Maps id(transient chunk-local instance) -> session-bound merge result,
+        # so children bound to a transient parent are relinked before merge.
+        replacements: dict[int, Any] = {}
+
         for table_name in topological_sort(ctx.dep_graph, ctx.scope_tables):
             result = ctx.local_results.get(table_name)
             if result is None:
@@ -406,19 +431,36 @@ class UpsertFlushStrategy:
                 ctx.on_event,
             )
             if self._on_conflict == "update":
-                self._flush_update(ctx, table_name, result)
+                self._flush_update(
+                    ctx, table_name, result, parent_attrs, replacements
+                )
             else:
                 self._flush_skip(ctx, table_name, result)
 
-    def _flush_update(self, ctx: FlushContext, table_name: str, result: Any) -> None:
+    def _flush_update(
+        self,
+        ctx: FlushContext,
+        table_name: str,
+        result: Any,
+        parent_attrs: dict[str, list[str]],
+        replacements: dict[int, Any],
+    ) -> None:
         from etielle.telemetry import FlushCompleted, FlushFailed, _emit
 
         merged_count = 0
         try:
-            for _key, instance in result.instances.items():
+            for key, instance in result.instances.items():
                 if isinstance(instance, dict):
                     continue
-                ctx.session.merge(instance)
+                for attr in parent_attrs.get(table_name, ()):
+                    bound = getattr(instance, attr, None)
+                    if bound is not None and id(bound) in replacements:
+                        setattr(instance, attr, replacements[id(bound)])
+                merged = ctx.session.merge(instance)
+                if merged is not instance:
+                    _replace_merged_instance(
+                        result, key, instance, merged, replacements
+                    )
                 merged_count += 1
             ctx.session.flush()
         except Exception as e:

--- a/tests/test_issue_85.py
+++ b/tests/test_issue_85.py
@@ -1,0 +1,132 @@
+"""Tests for issue #85: UpsertFlushStrategy(update) parent duplication."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from etielle import Field, TempField, get, stream
+from etielle.chunking import UpsertFlushStrategy
+
+Base = declarative_base()
+
+
+class Order(Base):
+    __tablename__ = "orders_85"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    customer = Column(String)
+
+
+class LineItem(Base):
+    __tablename__ = "line_items_85"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    sku = Column(String)
+    order_id = Column(Integer, ForeignKey("orders_85.id"))
+    orders_85 = relationship("Order")
+
+
+class Tag(Base):
+    __tablename__ = "tags_85"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String)
+
+
+class Item(Base):
+    __tablename__ = "items_85"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String)
+    tag_id = Column(Integer, ForeignKey("tags_85.id"))
+    tags_85 = relationship("Tag")
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+class TestUpsertFlushStrategyParentDuplication:
+    def test_tempfield_parent_with_child_in_same_chunk(self):
+        session = _session()
+        chunks = [
+            {
+                "orders": [{"id": 1, "customer": "Alice"}],
+                "items": [{"id": 10, "sku": "x", "order_id": 1}],
+            }
+        ]
+
+        (
+            stream(chunks, flush_strategy=UpsertFlushStrategy())
+            .goto("orders")
+            .each()
+            .map_to(
+                table=Order,
+                fields=[
+                    Field("customer", get("customer")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=LineItem,
+                fields=[
+                    Field("sku", get("sku")),
+                    TempField("id", get("id")),
+                    TempField("order_id", get("order_id")),
+                ],
+            )
+            .link_to(Order, by={"order_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Order).count() == 1
+        item = session.query(LineItem).one()
+        assert item.order_id == 1
+        session.close()
+
+    def test_load_eager_parent_not_duplicated_across_chunks(self):
+        session = _session()
+        eager = {"tags": [{"id": 1, "name": "t1"}]}
+        chunks = [
+            {"items": [{"id": 1, "name": "i0", "tag_id": 1}]},
+            {"items": [{"id": 2, "name": "i1", "tag_id": 1}]},
+        ]
+
+        (
+            stream(chunks, eager_roots=eager, flush_strategy=UpsertFlushStrategy())
+            .goto("tags")
+            .each()
+            .map_to(
+                table=Tag,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                ],
+            )
+            .load_eager(Tag)
+            .goto_root()
+            .goto("items")
+            .each()
+            .map_to(
+                table=Item,
+                fields=[
+                    Field("name", get("name")),
+                    TempField("id", get("id")),
+                    TempField("tag_id", get("tag_id")),
+                ],
+            )
+            .link_to(Tag, by={"tag_id": "id"})
+            .load(session)
+            .run()
+        )
+        session.commit()
+
+        assert session.query(Tag).count() == 1
+        items = session.query(Item).order_by(Item.name).all()
+        assert len(items) == 2
+        assert all(i.tag_id == 1 for i in items)
+        session.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #85

## Problem

`UpsertFlushStrategy(on_conflict="update")` could insert duplicate parent rows within a single pipeline run when parents were mapped with the standard `TempField("id", ...)` pattern (no PK on the instance). Children ended up bound to the duplicate parent.

Root cause: `_flush_update` called `session.merge(instance)` and discarded the return value. SQLAlchemy's `merge()` returns a session-bound copy; children in the chunk were already relationship-bound to the original transient parent. When the child was merged, SQLAlchemy's merge cascade re-merged that transient parent. Without a primary-key value on the instance, the cascade could not match by identity and inserted the parent a second time.

The same pattern compounded with `load_eager()`: the eager parent stayed transient after merge, and each subsequent chunk's child cascade inserted a fresh duplicate.

## Solution

- Track merge replacements and relink child relationship attributes before merging children (same pattern as `BufferedKeyFlushStrategy`).
- Update secondary indices when replacing transient instances with session-bound merge results, so `load_eager()` resident parents remain consistent across chunks.

## Tests

Added `tests/test_issue_85.py` covering:
- Parent + child in the same chunk with `TempField` id pattern
- `load_eager()` parent shared across multiple streaming chunks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d88bc3-7a70-4019-bc90-90de878ed316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d88bc3-7a70-4019-bc90-90de878ed316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

